### PR TITLE
Add isomorphic fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "apollo-client": "^1.9.0-1",
+    "isomorphic-fetch": "^2.2.1",
     "vue-apollo": "^2.1.0-beta.20"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import 'isomorphic-fetch'
 import VueApollo from 'vue-apollo'
 import { ApolloClient, createNetworkInterface } from 'apollo-client'
 


### PR DESCRIPTION
Out of the box, this module create an error, "fetch is not defined".
This is because apollo-client use fetch method and this method is not existing in nodeJS.

This PR is like a PoC, may be not the best way. Maybe it's better to add into server build via configuration ? (but how ?)

(NodeJS 8)

Thanks
