### PR TITLE
network-interface exports function and forwards context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
 {
   // Add apollo module
   modules: ['@nuxtjs/apollo'],
- 
+
   // Give apollo module options
   apollo: {
     networkInterfaces: {
@@ -31,7 +31,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
 - clients: `Object`
   - default: `String`
   - [otherClient]: `String` or `Object`
-  
+
 Example (`nuxt.config.js`):
 ```js
 module.exports = {
@@ -50,12 +50,15 @@ Then in `~/apollo/network-interfaces/default.js`:
 ```js
 import { createNetworkInterface } from 'apollo-client'
 
-export default createNetworkInterface({
-  uri: 'https://api.graph.cool/simple/v1/cj1dqiyvqqnmj0113yuqamkuu'
-})
+export default (ctx) => {
+  const networkInterface = createNetworkInterface({
+    uri: 'https://api.graph.cool/simple/v1/cj1dqiyvqqnmj0113yuqamkuu'
+  })
+  // here you can place your middleware. ctx has the context forwarded from Nuxt
+  return networkInterface
+}
 ```
 
 ## Usage
 
 See [Official example](https://github.com/nuxt/nuxt.js/tree/dev/examples/vue-apollo) and [vue-apollo](https://github.com/Akryum/vue-apollo).
-  

--- a/plugin.js
+++ b/plugin.js
@@ -15,9 +15,7 @@ export default (ctx) => {
 
   <% Object.keys(options.networkInterfaces).forEach((key) => { %>
     let networkInterface = require('<%= options.networkInterfaces[key] %>')
-    console.log("networkInterface",networkInterface)
     networkInterface = networkInterface.default(ctx) || networkInterface(ctx)
-    console.log("second call",networkInterface)
     const <%= key %>Client = new ApolloClient({
       networkInterface,
       ...(isServer ? {

--- a/plugin.js
+++ b/plugin.js
@@ -14,8 +14,10 @@ export default (ctx) => {
   const { isClient, isServer, app, route, beforeNuxtRender, store } = ctx
 
   <% Object.keys(options.networkInterfaces).forEach((key) => { %>
-    let networkInterface = require('<%= options.networkInterfaces[key](ctx) %>')
-    networkInterface = networkInterface.default(ctx) || networkInterface
+    let networkInterface = require('<%= options.networkInterfaces[key] %>')
+    console.log("networkInterface",networkInterface)
+    networkInterface = networkInterface.default(ctx) || networkInterface(ctx)
+    console.log("second call",networkInterface)
     const <%= key %>Client = new ApolloClient({
       networkInterface,
       ...(isServer ? {

--- a/plugin.js
+++ b/plugin.js
@@ -5,15 +5,17 @@ import { ApolloClient, createNetworkInterface } from 'apollo-client'
 
 Vue.use(VueApollo)
 
-export default ({ isClient, isServer, app, route, beforeNuxtRender, store }) => {
+export default (ctx) => {
 
   const providerOptions = {
     clients: {}
   }
 
+  const { isClient, isServer, app, route, beforeNuxtRender, store } = ctx
+
   <% Object.keys(options.networkInterfaces).forEach((key) => { %>
-    let networkInterface = require('<%= options.networkInterfaces[key] %>')
-    networkInterface = networkInterface.default || networkInterface
+    let networkInterface = require('<%= options.networkInterfaces[key](ctx) %>')
+    networkInterface = networkInterface.default(ctx) || networkInterface
     const <%= key %>Client = new ApolloClient({
       networkInterface,
       ...(isServer ? {
@@ -36,7 +38,7 @@ export default ({ isClient, isServer, app, route, beforeNuxtRender, store }) => 
 
   if (isServer) {
     beforeNuxtRender(async ({ Components, nuxtState }) => {
-      await app.apolloProvider.prefetchAll({ route, store }, Components)
+      await app.apolloProvider.prefetchAll(ctx, Components)
       nuxtState.apollo = app.apolloProvider.getStates()
     })
   }


### PR DESCRIPTION
This PR changes the behaviour of the network interface. Instead exporting the network interface users should export a function which returns the network interface, it receives the context as argument. This offers the opportunity to apply middleware directly inside of the network interface functions.

Beside that, the whole context is being forwarded for the prefetch argument of $apollo. 