### PR TITLE
add the possibility to return an object rather the networkInterface directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,16 @@ export default (ctx) => {
     uri: 'https://api.graph.cool/simple/v1/cj1dqiyvqqnmj0113yuqamkuu'
   })
   // here you can place your middleware. ctx has the context forwarded from Nuxt
-  return networkInterface
+
+  // you can return the networkInterface directly or return an object with additional
+  // apollo-client options
+  // return networkInterface
+
+  // alternative return a object with constructor options of apollo-client
+  return {
+    networkInterface,
+    dataIdFromObject: o => o.id
+  }
 }
 ```
 

--- a/plugin.js
+++ b/plugin.js
@@ -16,14 +16,15 @@ export default (ctx) => {
   <% Object.keys(options.networkInterfaces).forEach((key) => { %>
     let networkInterface = require('<%= options.networkInterfaces[key] %>')
     networkInterface = networkInterface.default(ctx) || networkInterface(ctx)
-    const <%= key %>Client = new ApolloClient({
-      networkInterface,
+
+    const opts = Object.assign(
       ...(isServer ? {
         ssrMode: true
       } : {
         initialState: window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %>,
         ssrForceFetchDelay: 100
-      })
+      },networkInterface.constructor === Object ? networkInterface : {networkInterface})
+    const <%= key %>Client = new ApolloClient()
     })
     <% if (key === 'default') { %>
       providerOptions.<%= key %>Client = <%= key %>Client

--- a/plugin.js
+++ b/plugin.js
@@ -24,7 +24,7 @@ export default (ctx) => {
         initialState: window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %>,
         ssrForceFetchDelay: 100
       },networkInterface.constructor === Object ? networkInterface : {networkInterface})
-    const <%= key %>Client = new ApolloClient()
+    const <%= key %>Client = new ApolloClient(opts)
     })
     <% if (key === 'default') { %>
       providerOptions.<%= key %>Client = <%= key %>Client

--- a/plugin.js
+++ b/plugin.js
@@ -17,15 +17,15 @@ export default (ctx) => {
     let networkInterface = require('<%= options.networkInterfaces[key] %>')
     networkInterface = networkInterface.default(ctx) || networkInterface(ctx)
 
-    const opts = Object.assign(
-      ...(isServer ? {
+    const opts = isServer ? {
         ssrMode: true
-      } : {
-        initialState: window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %>,
-        ssrForceFetchDelay: 100
-      },networkInterface.constructor === Object ? networkInterface : {networkInterface})
+    } : {
+      initialState: window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %>,
+      ssrForceFetchDelay: 100
+    }
+    Object.assign(opts, networkInterface.constructor === Object ? networkInterface : {networkInterface})
     const <%= key %>Client = new ApolloClient(opts)
-    })
+    
     <% if (key === 'default') { %>
       providerOptions.<%= key %>Client = <%= key %>Client
     <% } else { %>


### PR DESCRIPTION
This PR merges default constructor options of new ApolloClient() and merges the default option with returned vaules of networkInterface. The old behaviour of returning networkInterface directly is still supported.

I created this, because its not possible to modify the construcotr options on runtime, with this minor change the constructor options are fully customizable