### PR TITLE
Fix #29 apollo module not working in SPA mode

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -21,7 +21,7 @@ export default (ctx) => {
       ...(isServer ? {
         ssrMode: true
       } : {
-        initialState: window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %>,
+        initialState: window.__NUXT__ ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null,
         ssrForceFetchDelay: 100
       })
     })


### PR DESCRIPTION
Quick fix for #29, in SPA mode `window.__NUXT__` seems to be unavailable which cause the page not loading. I also assume `window.__NUXT__.apollo` will be there if `window.__NUXT__` is available.