### PR TITLE
Fix client.default is not a function

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -17,7 +17,7 @@ export default (ctx) => {
   <% Object.keys(options.clientConfigs).forEach((key) => { %>
     let client = require('<%= options.clientConfigs[key] %>')
     // es6 module default export or not
-    client = client.default(ctx) || client(ctx)
+    client = (client.default || client)(ctx)
     const cache = client.cache || new InMemoryCache()
 
     const opts = process.server ? {


### PR DESCRIPTION
Fix a type error when commonjs is used. `client.default` will be `undefined`. This change determines the export before calling it.