### PR TITLE
Fix apolloProvider breaking change

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -45,6 +45,9 @@ export default (ctx) => {
   <% }) %>
 
   const apolloProvider = new VueApollo(providerOptions)
+  // Allow access to the provider in the context
+  app.apolloProvider = apolloProvider
+  // Install the provider into the app
   app.provide = apolloProvider.provide()
 
   if (process.server) {


### PR DESCRIPTION
Latest release breaks code relying on `context.app.apolloProvider`.