### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 export default (ctx) => {
   const httpLink = new HttpLink({ uri: 'http://localhost:8000/graphql' })
 
-  // auth token
-  let token = process.server ? ctx.req.session : window.__NUXT__.state.session
 
   // middleware
   const middlewareLink = new ApolloLink((operation, forward) => {
+    const token = process.server ? ctx.req.session : window.__NUXT__.state.session
+
     operation.setContext({
       headers: { authorization: `Bearer ${token}` }
     })


### PR DESCRIPTION
Token must be set inside the middleware function, because the token declaration in the previous version is only initiated on page load. This causes bugs where the authorization header isn't changed on a login / logout until a page refresh.