### PR TITLE
[WIP] Fix build error and backward compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
   }
 ```
 
-Then in `~/apollo/client-configs/default.js`:
+Then in `~/apollo/client-configs/anotherClient.js`:
 
 ```js	
 export default (ctx) => {	
@@ -105,6 +105,13 @@ export default (ctx) => {
     // clientState: { resolvers: { ... }, defaults: { ... } }
   }	
 }	
+```
+
+If you don't want to use default getAuth token, you do this on the getAuth config
+```
+...
+getAuth: () => undefined
+...
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -31,28 +31,81 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
       default: {
         httpEndpoint: 'http://localhost:4000',
         // You can use `wss` for secure connection (recommended in production)
+
         // Use `null` to disable subscriptions
-        wsEndpoint: 'http://localhost:4000',
-        // LocalStorage token
-        tokenName: 'apollo-token',
+        // wsEndpoint: 'ws://localhost:4000',
+
+        // CookieStorage token
+        // tokenName: 'your-token-name',
+
         // Enable Automatic Query persisting with Apollo Engine
-        persisting: false, // Optional
+        // persisting: false,
+
         // Use websockets for everything (no HTTP)
         // You need to pass a `wsEndpoint` for this to work
-        websocketsOnly: false // Optional
+        // websocketsOnly: false,
+    
+        // Override default http link
+        // link: yourLink,
+    
+        // Override default cache
+        // cache: yourCache,
+    
+        // Override the way the Authorization header is set
+        // getAuth: yourFunction
+    
+        // Additional ApolloClient options
+        // apollo: { ... },
+    
+        // Client local data (see apollo-link-state)
+        // clientState: { resolvers: { ... }, defaults: { ... } }
       },
-      test: {
-        httpEndpoint: 'http://localhost:5000',
-        wsEndpoint: 'http://localhost:5000',
-        tokenName: 'apollo-token'
+      anotherone: '~/apollo/client-configs/anotherClient.js',
+      anothertwo: {
+        httpEndpoint: 'http://localhost:5000'
       }
     }
   }
-}
 ```
 
 Then in `~/apollo/client-configs/default.js`:
 
+```js	
+export default (ctx) => {	
+  return {	
+    httpEndpoint: 'http://localhost:4000',
+    // You can use `wss` for secure connection (recommended in production)
+
+    // Use `null` to disable subscriptions
+    // wsEndpoint: 'ws://localhost:4000',
+
+    // CookieStorage token
+    // tokenName: 'your-token-name',
+
+    // Enable Automatic Query persisting with Apollo Engine
+    // persisting: false,
+
+    // Use websockets for everything (no HTTP)
+    // You need to pass a `wsEndpoint` for this to work
+    // websocketsOnly: false,
+
+    // Override default http link
+    // link: yourLink,
+
+    // Override default cache
+    // cache: yourCache,
+
+    // Override the way the Authorization header is set
+    // getAuth: yourFunction
+
+    // Additional ApolloClient options
+    // apollo: { ... },
+
+    // Client local data (see apollo-link-state)
+    // clientState: { resolvers: { ... }, defaults: { ... } }
+  }	
+}	
+```
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const nodeExternals = require('webpack-node-externals')
 
 module.exports = function nuxtApollo(moduleOptions) {
   // Fetch `apollo` option from `nuxt.config.js`
@@ -13,9 +14,13 @@ module.exports = function nuxtApollo(moduleOptions) {
   // Sanitize clientConfigs option
   Object.keys(clientConfigs).forEach((key) => {
     if (typeof clientConfigs[key] !== 'object') {
-      throw new Error(`[Apollo module] Client configuration "${key}" should be an object.`)
-    } else if (typeof clientConfigs[key].httpEndpoint !== 'string' || (typeof clientConfigs[key].httpEndpoint === 'string' && /^https?:\/\//.test(clientConfigs[key]))) {
-        throw new Error(`[Apollo module] Client endpoint configuration "${key}" should be a path to an exported Apollo Client config object.`)
+      if (typeof clientConfigs[key] !== 'string' || (typeof clientConfigs[key] === 'string' && /^https?:\/\//.test(clientConfigs[key]))) {
+        throw new Error(`[Apollo module] Client configuration "${key}" should be an object or a path to an exported Apollo Client config.`)
+      }
+    } else {
+      if (typeof clientConfigs[key].httpEndpoint !== 'string' || (typeof clientConfigs[key].httpEndpoint === 'string' && /^https?:\/\//.test(clientConfigs[key]))) {
+        throw new Error(`[Apollo module] Client configuration "${key}" must define httpEndpoint.`)
+      }
     }
   })
 
@@ -26,7 +31,7 @@ module.exports = function nuxtApollo(moduleOptions) {
   })
 
   // Add vue-apollo and apollo-client in common bundle
-  this.addVendor(['vue-apollo', 'apollo-client', 'apollo-cache-inmemory', 'vue-cli-plugin-apollo', 'js-cookie'])
+  this.addVendor(['vue-apollo', 'apollo-client', 'apollo-cache-inmemory', 'js-cookie'])
  
   // Add graphql loader
   this.extendBuild((config) => {
@@ -40,5 +45,12 @@ module.exports = function nuxtApollo(moduleOptions) {
       delete gqlRules.exclude
     }
     config.module.rules.push(gqlRules)
+    if (isServer) {
+      config.externals = [
+        nodeExternals({
+          whitelist: [/^vue-cli-plugin-apollo/]
+        })
+      ]
+    }
   })
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = function nuxtApollo(moduleOptions) {
       }
     } else {
       if (typeof clientConfigs[key].httpEndpoint !== 'string' || (typeof clientConfigs[key].httpEndpoint === 'string' && /^https?:\/\//.test(clientConfigs[key]))) {
-        throw new Error(`[Apollo module] Client configuration "${key}" must define httpEndpoint.`)
+        if (typeof clientConfigs[key].link !== 'string' || (typeof clientConfigs[key].link === 'string' && /^https?:\/\//.test(clientConfigs[key]))) {
+          throw new Error(`[Apollo module] Client configuration "${key}" must define httpEndpoint or link option.`)
+        }
       }
     }
   })

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function nuxtApollo(moduleOptions) {
   this.addVendor(['vue-apollo', 'apollo-client', 'apollo-cache-inmemory', 'js-cookie'])
  
   // Add graphql loader
-  this.extendBuild((config) => {
+  this.extendBuild((config, {isServer}) => {
     config.resolve.extensions = config.resolve.extensions.concat('.graphql', '.gql')
     const gqlRules = {
       test: /\.(graphql|gql)$/,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
     "vue-apollo": "^3.0.0-beta.16",
-    "vue-cli-plugin-apollo": "^0.13.6"
+    "vue-cli-plugin-apollo": "^0.13.6",
+    "webpack-node-externals": "^1.7.2"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -56,7 +56,10 @@ export default (ctx, inject) => {
         clientState: '<%= options.clientConfigs[key].clientState %>'
       }
     <% } else if (typeof options.clientConfigs[key] === 'string') { %>
-      const <%= key %>ClientConfig = require('<%= options.clientConfigs[key] %>').default(ctx) || require('<%= options.clientConfigs[key] %>')(ctx)
+      let <%= key %>ClientConfig = require('<%= options.clientConfigs[key] %>').default(ctx) || require('<%= options.clientConfigs[key] %>')(ctx)
+      if (!<%= key %>ClientConfig.getAuth) {
+        <%= key %>ClientConfig.getAuth = defaultGetAuth
+      }
     <% } %>
 
     // Create apollo client

--- a/plugin.js
+++ b/plugin.js
@@ -21,39 +21,43 @@ export default (ctx, inject) => {
       <%= key %>Cache.restore(window.__NUXT__ ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
     }
 
-    const <%= key %>ClientConfig = {
-      // You can use `https` for secure connection (recommended in production)
-      httpEndpoint: '<%= options.clientConfigs[key].httpEndpoint %>',
-      // You can use `wss` for secure connection (recommended in production)
-      // Use `null` to disable subscriptions
-      wsEndpoint: '<%= options.clientConfigs[key].wsEndpoint %>',
-      // LocalStorage token
-      tokenName: '<%= options.clientConfigs[key].tokenName %>',
-      // Enable Automatic Query persisting with Apollo Engine
-      persisting: '<%= options.clientConfigs[key].persisting %>',
-      // Use websockets for everything (no HTTP)
-      // You need to pass a `wsEndpoint` for this to work
-      websocketsOnly: '<%= options.clientConfigs[key].websocketsOnly %>',
-      // Is being rendered on the server?
-      ssr: process.server ? true : false,
-  
-      // Override default http link
-      link: '<%= options.clientConfigs[key].link %>',
-  
-      // Override default cache
-      cache: <%= key %>Cache,
-  
-      // Override the way the Authorization header is set
-      getAuth: '<%= options.clientConfigs[key].getAuth %>' || defaultGetAuth
-  
-      // Additional ApolloClient options
-      // apollo: { ... },
-      apollo: '<%= options.clientConfigs[key].apollo %>',
-  
-      // Client local data (see apollo-link-state)
-      // clientState: { resolvers: { ... }, defaults: { ... } }\
-      clientState: '<%= options.clientConfigs[key].clientState %>'
-    }
+    <% if (typeof options.clientConfigs[key] === 'object') { %>
+      const <%= key %>ClientConfig = {
+        // You can use `https` for secure connection (recommended in production)
+        httpEndpoint: '<%= options.clientConfigs[key].httpEndpoint %>',
+        // You can use `wss` for secure connection (recommended in production)
+        // Use `null` to disable subscriptions
+        wsEndpoint: '<%= options.clientConfigs[key].wsEndpoint %>',
+        // LocalStorage token
+        tokenName: '<%= options.clientConfigs[key].tokenName %>',
+        // Enable Automatic Query persisting with Apollo Engine
+        persisting: '<%= options.clientConfigs[key].persisting %>',
+        // Use websockets for everything (no HTTP)
+        // You need to pass a `wsEndpoint` for this to work
+        websocketsOnly: '<%= options.clientConfigs[key].websocketsOnly %>',
+        // Is being rendered on the server?
+        ssr: process.server ? true : false,
+    
+        // Override default http link
+        link: '<%= options.clientConfigs[key].link %>',
+    
+        // Override default cache
+        cache: <%= key %>Cache,
+    
+        // Override the way the Authorization header is set
+        getAuth: '<%= options.clientConfigs[key].getAuth %>' || defaultGetAuth,
+    
+        // Additional ApolloClient options
+        // apollo: { ... },
+        apollo: '<%= options.clientConfigs[key].apollo %>',
+    
+        // Client local data (see apollo-link-state)
+        // clientState: { resolvers: { ... }, defaults: { ... } }\
+        clientState: '<%= options.clientConfigs[key].clientState %>'
+      }
+    <% } else if (typeof options.clientConfigs[key] === 'string') { %>
+      const <%= key %>ClientConfig = require('<%= options.clientConfigs[key] %>').default(ctx) || require('<%= options.clientConfigs[key] %>')(ctx)
+    <% } %>
 
     // Create apollo client
     let <%= key %>ApolloCreation = createApolloClient({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,6 +2413,10 @@ vue-cli-plugin-apollo@^0.13.6:
     nodemon "^1.17.4"
     subscriptions-transport-ws "^0.9.9"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
 whatwg-fetch@2.0.3, whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"


### PR DESCRIPTION
@dohomi 

Now people doesn't need to change anything after they upgraded :)

And I remember why I used `webpack-node-externals`, if I put `vue-cli-plugin-apollo` into `addVendor`
I get this error
```
 ERROR  Failed to compile with 1 errors                                                                                                                13:27:44
 error  in ./node_modules/vue-cli-plugin-apollo/index.js

Module parse failed: Unexpected token (45:10)
You may need an appropriate loader to handle this file type.
|         .use('eslint-loader')
|         .tap(options => ({
|           ...options,
|           cacheIdentifier: options.cacheIdentifier + id,
|         }))

 @ multi vue vue-router vue-meta vuex vue-apollo apollo-client apollo-cache-inmemory vue-cli-plugin-apollo js-cookie
```
`webpack-node-externals` is the solution that I found. Also see https://github.com/nuxt-community/apollo-module/pull/106#issuecomment-395309447