### PR TITLE
Support custom authorization schemes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
   apollo: {
     tokenName: 'yourApolloTokenName', // optional, default: apollo-token
     includeNodeModules: true, // optional, default: false (this includes graphql-tag for node_modules folder)
+    authScheme: 'Basic', // optional, default: 'Bearer'
     // required
     clientConfigs: {
       default: {

--- a/lib/module.js
+++ b/lib/module.js
@@ -19,6 +19,7 @@ module.exports = function (moduleOptions) {
     }
   })
   options.token = options.token || 'apollo-token'
+  options.authScheme = options.authScheme || 'Bearer'
   // Add plugin for vue-apollo
   this.addPlugin({
     options,

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -12,6 +12,7 @@ export default (ctx, inject) => {
   const providerOptions = { clients: {} }
   const { app, beforeNuxtRender, req } = ctx
   const AUTH_TOKEN = '<%= options.token %>'
+  const AUTH_SCHEME = '<%= options.authScheme %> '
 
   // Config
   <% Object.keys(options.clientConfigs).forEach((key) => { %>
@@ -26,7 +27,7 @@ export default (ctx, inject) => {
           } else {
             token = jsCookie.get(tokenName)
           }
-          return token ? 'Bearer ' + token : ''
+          return token ? AUTH_SCHEME + token : ''
       }
       const options = Object.assign({}, currentOptions, {
         ssr: !!process.server,


### PR DESCRIPTION
Currently only Bearer authorization scheme is supported. This PR adds option to modify the auth scheme used.
To use a custom scheme:
```
apollo: {
  authScheme: 'Basic',
  ... // other options
}
```
Closes #112 