### PR TITLE
[add] documentation for 'httpLinkOptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
       default: {
         // required  
         httpEndpoint: 'http://localhost:4000',
+        // optional
+        // See https://www.apollographql.com/docs/link/links/http.html#options
+        httpLinkOptions: {
+          credentials: 'same-origin'
+        },
         // You can use `wss` for secure connection (recommended in production)
         // Use `null` to disable subscriptions
         wsEndpoint: 'http://localhost:4000', // optional


### PR DESCRIPTION
along with https://github.com/Akryum/vue-cli-plugin-apollo/pull/42/files,
added documentation for `httpLinkOptions`.