### PR TITLE
feat: set token expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Once the setup is completed you have a successfully enabled `vue-apollo` in your
 You have following methods for authentication available:
 ```js
  // set your graphql-token
- this.$apolloHelpers.onLogin(token /* you can set custom token expiration on second argument, and if not default you can pass in client as third argument */)
+ this.$apolloHelpers.onLogin(token /* if not default you can pass in client as second argument, and you can set custom token expiration on third argument */)
  // unset your graphql-token
  this.$apolloHelpers.onLogout(/* if not default you can pass in client as second argument */)
  // get your current token (we persist token in a cookie)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
   // Give apollo module options
   apollo: {
     tokenName: 'yourApolloTokenName', // optional, default: apollo-token
+    tokenExpires: 10, // optional, default: 7
     includeNodeModules: true, // optional, default: false (this includes graphql-tag for node_modules folder)
     authenticationType: 'Basic', // optional, default: 'Bearer'
     // required
@@ -111,7 +112,7 @@ Once the setup is completed you have a successfully enabled `vue-apollo` in your
 You have following methods for authentication available:
 ```js
  // set your graphql-token
- this.$apolloHelpers.onLogin(token, /* if not default you can pass in client as second argument */)
+ this.$apolloHelpers.onLogin(token /* you can set custom token expiration on second argument, and if not default you can pass in client as third argument */)
  // unset your graphql-token
  this.$apolloHelpers.onLogout(/* if not default you can pass in client as second argument */)
  // get your current token (we persist token in a cookie)

--- a/lib/module.js
+++ b/lib/module.js
@@ -29,6 +29,7 @@ module.exports = function (moduleOptions) {
   })
 
   options.tokenName = options.tokenName || 'apollo-token'
+  options.tokenExpires = options.tokenExpires || 7
   options.authenticationType = options.authenticationType || 'Bearer'
 
   // Add plugin for vue-apollo

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -12,7 +12,7 @@ export default (ctx, inject) => {
   const providerOptions = { clients: {} }
   const { app, beforeNuxtRender, req } = ctx
   const AUTH_TOKEN_NAME = '<%= options.tokenName %>'
-  const AUTH_TOKEN_EXPIRES = '<%= options.tokenExpires %>'
+  const AUTH_TOKEN_EXPIRES = <%= options.tokenExpires %>
   const AUTH_TYPE = '<%= options.authenticationType %> '
 
   // Config

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -97,7 +97,7 @@ export default (ctx, inject) => {
   }
 
   inject('apolloHelpers', {
-    onLogin: async (token, tokenExpires = AUTH_TOKEN_EXPIRES, apolloClient = apolloProvider.defaultClient) => {
+    onLogin: async (token, apolloClient = apolloProvider.defaultClient, tokenExpires = AUTH_TOKEN_EXPIRES) => {
       if (token) {
         jsCookie.set(AUTH_TOKEN_NAME, token, { expires: tokenExpires })
       } else {

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -12,6 +12,7 @@ export default (ctx, inject) => {
   const providerOptions = { clients: {} }
   const { app, beforeNuxtRender, req } = ctx
   const AUTH_TOKEN_NAME = '<%= options.tokenName %>'
+  const AUTH_TOKEN_EXPIRES = '<%= options.tokenExpires %>'
   const AUTH_TYPE = '<%= options.authenticationType %> '
 
   // Config
@@ -96,9 +97,9 @@ export default (ctx, inject) => {
   }
 
   inject('apolloHelpers', {
-    onLogin: async (token, apolloClient = apolloProvider.defaultClient) => {
+    onLogin: async (token, tokenExpires = AUTH_TOKEN_EXPIRES, apolloClient = apolloProvider.defaultClient) => {
       if (token) {
-        jsCookie.set(AUTH_TOKEN_NAME, token)
+        jsCookie.set(AUTH_TOKEN_NAME, token, { expires: tokenExpires })
       } else {
         jsCookie.remove(AUTH_TOKEN_NAME)
       }

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -69,7 +69,7 @@
                         mutation: authenticateUserGql,
                         variables: credentials
                     }).then(({data}) => data && data.authenticateUser)
-                    await this.$apolloHelpers.onLogin(res.token)
+                    await this.$apolloHelpers.onLogin(res.token, undefined, 7)
                     this.successfulData = res
                     this.isAuthenticated = true
                 } catch (e) {


### PR DESCRIPTION
Set token expiration on apollo option
```js
{
  // Add apollo module
  modules: ['@nuxtjs/apollo'],

  // Give apollo module options
  apollo: {
    tokenName: 'yourApolloTokenName', // optional, default: apollo-token
    tokenExpires: 10, // optional, default: 7
    ...
  }
}
```
and apolloHelpers.onLogin function
```js
this.$apolloHelpers.onLogin(token, tokenExpires, apolloClient)
```
what do you guys think?