### PR TITLE
Support empty string as authenticationType

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -30,7 +30,7 @@ module.exports = function (moduleOptions) {
 
   options.tokenName = options.tokenName || 'apollo-token'
   options.tokenExpires = options.tokenExpires || 7
-  options.authenticationType = options.authenticationType || 'Bearer'
+  options.authenticationType = (options.authenticationType === undefined) ? 'Bearer' : options.authenticationType
 
   // Add plugin for vue-apollo
   this.addPlugin({


### PR DESCRIPTION
This change allows the `authenticationType` config option to accept an empty string that is not overridden to 'Bearer' by default.

Some GraphQL endpoints, including Amazon AppSync when using Oauth, require an authorization header in the format: 

`Authorization: <token>` instead of the more standard `Authorization: Bearer <token>`.

Currently, passing an empty string `''` to the config for `authenticationType` results in the `||` operator evaluating that as falsy and overwriting this option with the default `'Bearer'`.