### PR TITLE
Add errorhandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
     tokenExpires: 10, // optional, default: 7
     includeNodeModules: true, // optional, default: false (this includes graphql-tag for node_modules folder)
     authenticationType: 'Basic', // optional, default: 'Bearer'
+    // optional
+    errorHandler (error) {
+      console.log('%cError', 'background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;', error.message)
+    },
     // required
     clientConfigs: {
       default: {

--- a/lib/module.js
+++ b/lib/module.js
@@ -31,6 +31,9 @@ module.exports = function (moduleOptions) {
   options.tokenName = options.tokenName || 'apollo-token'
   options.tokenExpires = options.tokenExpires || 7
   options.authenticationType = options.authenticationType || 'Bearer'
+  if (options.hasOwnProperty('errorHandler') && typeof options.errorHandler !== 'function') {
+    throw new Error(`[Apollo module] errorHandler must be a function.`)
+  }
 
   // Add plugin for vue-apollo
   this.addPlugin({

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -72,9 +72,13 @@ export default (ctx, inject) => {
   <% }) %>
 
   const vueApolloOptions = Object.assign(providerOptions, {
-      errorHandler (error) {
-         console.log('%cError', 'background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;', error.message)
-      }
+      <% if (options.errorHandler) { %>
+        <%= options.errorHandler %>
+      <% } else { %>
+        errorHandler (error) {
+          console.log('%cError', 'background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;', error.message)
+        }
+      <% } %>
   })
 
   const apolloProvider = new VueApollo(vueApolloOptions)


### PR DESCRIPTION
resolve #149

# Why did I send this PR?
Because default error handler was not configurable on this module.
and I would like to hook all apollo errors, such as authorization error [like this](https://github.com/Akryum/vue-apollo/blob/master/tests/demo/src/vue-apollo.js#L58-L71)

# What did I do
added `errorHandler` in `nuxt.config.js`