### PR TITLE
use exact version for vue-apollo

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cookie": "^0.3.1",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
-    "vue-apollo": "^3.0.0-beta.19",
+    "vue-apollo": "3.0.0-beta.19",
     "vue-cli-plugin-apollo": "^0.16.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Otherwise vue-apollo@3.0.0-beta.20 will be installed which contains breaking changes:
[vue-apollo beta 20 release notes](https://github.com/Akryum/vue-apollo/releases/tag/v3.0.0-beta.20)