### PR TITLE
Fixes duplicate loading of graphql-tag/loader rules

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -61,7 +61,10 @@ module.exports = function (moduleOptions) {
       delete gqlRules.exclude
     }
 
-    config.module.rules.push(gqlRules)
+
+    if( ! config.module.rules.find( (rule) => rule.use === 'graphql-tag/loader' ) ){
+      config.module.rules.push(gqlRules)
+    }
     if (isServer) {
       // Adding proper way of handling whitelisting with Nuxt 2
       if (this.options.build.transpile) {


### PR DESCRIPTION
It appears the graphql-tag/loader rules get pushed multiple times in some
situations. I experienced it when nuxt recompiled after a changed file.
It may be specific to nuxt v2.1.0 and webpack 4.