### PR TITLE
uses inMemoryCache Options when set in clientConfig

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -45,7 +45,7 @@ export default (ctx, inject) => {
 
       const <%= key %>Cache = <%= key %>ClientConfig.cache
         ? <%= key %>ClientConfig.cache
-        : new InMemoryCache()
+        : new InMemoryCache(<%= key %>ClientConfig.inMemoryCacheOptions || {})
 
       if (!process.server) {
         <%= key %>Cache.restore(window.__NUXT__ ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)


### PR DESCRIPTION
Currently the client option "inMemoryCache" isn't used in nuxt-apollo, even when it's referenced in the docs.

This PR fixes that by using the client option "inMemoryCache" when create a new InMemoryCache instance. If the client option "inMemoryCache" is not set, a empty object "{}" get passed to the new InMemoryCache instance.