### PR TITLE
Add token validation method

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -27,7 +27,7 @@ export default (ctx, inject) => {
         } else {
           token = jsCookie.get(<%= key %>TokenName)
         }
-        return token ? AUTH_TYPE + token : ''
+        return token && <%= key %>ClientConfig.validateToken(token) ? AUTH_TYPE + token : ''
       }
 
       let <%= key %>ClientConfig;
@@ -42,6 +42,12 @@ export default (ctx, inject) => {
 
         <%= key %>ClientConfig = <%= key %>ClientConfig(ctx)
       <% } %>
+
+      const <%= key %>ValidateToken = () => true
+
+      if (!<%= key %>ClientConfig.validateToken) {
+        <%= key %>ClientConfig.validateToken = <%= key %>ValidateToken
+      }
 
       const <%= key %>Cache = <%= key %>ClientConfig.cache
         ? <%= key %>ClientConfig.cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,17 @@
   "requires": true,
   "dependencies": {
     "@apollographql/apollo-tools": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.2.7.tgz",
-      "integrity": "sha512-rsn4uN12gZWME+m9CLnUk+ImY+blKdWFFdS6TlQheXC7XA85twjQmOY0/n05qUtrxx1dM5QUXw1qLCZ4emWYbQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.2.9.tgz",
+      "integrity": "sha512-AEIQwPkS0QLbkpb6WyRhV4aOMxuErasp47ABv5niDKOasQH8mrD8JSGKJAHuQxVe4kB8DE9sLRoc5qeQ0KFCHA==",
       "requires": {
-        "apollo-env": "0.2.4"
-      }
-    },
-    "@apollographql/apollo-upload-server": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-upload-server/-/apollo-upload-server-5.0.3.tgz",
-      "integrity": "sha512-tGAp3ULNyoA8b5o9LsU2Lq6SwgVPUOKAqKywu2liEtTvrFSGPrObwanhYwArq3GPeOqp2bi+JknSJCIU3oQN1Q==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.0.0-rc.1",
-        "busboy": "^0.2.14",
-        "object-path": "^0.11.4"
+        "apollo-env": "0.2.5"
       }
     },
     "@apollographql/graphql-playground-html": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.4.tgz",
-      "integrity": "sha512-gwvaQO6/Hv4DEwhDLmmu2tzCU9oPjC5Xl9Kk8Yd0IxyKhYLlLalmkMMjsZLzU5H3fGaalLD96OYfxHL0ClVUDQ=="
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.6.tgz",
+      "integrity": "sha512-lqK94b+caNtmKFs5oUVXlSpN3sm5IXZ+KfhMxOtr0LR2SqErzkoJilitjDvJ1WbjHlxLI7WtCjRmOLdOGJqtMQ=="
     },
     "@babel/code-frame": {
       "version": "7.0.0",
@@ -832,15 +822,6 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.1.5.tgz",
-      "integrity": "sha512-WsYRwQsFhVmxkAqwypPTZyV9GpkqMEaAr2zOItOmqSX2GBFaI+eq98CN81e13o0zaUKJOQGYyjhNVqj56nnkYg==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "@babel/template": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -1399,14 +1380,14 @@
       "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
     },
     "@types/node": {
-      "version": "10.12.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
-      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA=="
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
     },
     "@types/range-parser": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
-      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.2",
@@ -1818,89 +1799,109 @@
       }
     },
     "apollo-cache": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.20.tgz",
-      "integrity": "sha512-+Du0/4kUSuf5PjPx0+pvgMGV12ezbHA8/hubYuqRQoy/4AWb4faa61CgJNI6cKz2mhDd9m94VTNKTX11NntwkQ==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.22.tgz",
+      "integrity": "sha512-8PoxhQLISj2oHwT7i/r4l+ly4y3RKZls+dtXzAewu3U77P9dNZKhYkRNAhx9iEfsrNoHgXBV8vMp64hb1uYh+g==",
       "requires": {
-        "apollo-utilities": "^1.0.25"
+        "apollo-utilities": "^1.0.27"
       }
     },
     "apollo-cache-control": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.3.2.tgz",
-      "integrity": "sha512-/fhgCWGEoTsgyA83usy/1NvJWi6hbD4rSGO5jvyNNtMZ9ledOvKUvIdzSQ1r5hxK5yds/eehWXhMJ4Pu200qrQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.4.0.tgz",
+      "integrity": "sha512-WuriaNQIugTE8gYwfBWWCbbQTSKul/cV4JMi5UgqNIUvjHvnKZQLKbt5uYWow6QQNMkLT9hey8QPYkWpogkeSA==",
       "requires": {
         "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.3.2"
+        "graphql-extensions": "0.4.0"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.0.tgz",
+          "integrity": "sha512-8TUgIIUVpXWOcqq9RdmTSHUrhc3a/s+saKv9cCl8TYWHK9vyJIdea7ZaSKHGDthZNcsN+C3LulZYRL3Ah8ukoA==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.2.6"
+          }
+        }
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.10.tgz",
-      "integrity": "sha512-cJL8xxX2iytludvxY4goxYJ41n8avXirAjQkEwgSvGqrEzC0PG2DwtHZZh1QTnRRuM1rgj4MKiUiX/Ykhc5L+Q==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.12.tgz",
+      "integrity": "sha512-jxWcW64QoYQZ09UH6v3syvCCl3MWr6bsxT3wYYL6ORi8svdJUpnNrHTcv5qXqJYVg/a+NHhfEt+eGjJUG2ytXA==",
       "requires": {
-        "apollo-cache": "^1.1.20",
-        "apollo-utilities": "^1.0.25",
-        "optimism": "^0.6.6"
+        "apollo-cache": "^1.1.22",
+        "apollo-utilities": "^1.0.27",
+        "optimism": "^0.6.8"
       }
     },
     "apollo-client": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.6.tgz",
-      "integrity": "sha512-RsZVMYone7mu3Wj4sr7ehctN8pdaHsP4X1Sv6Ly4gZ/YDetCCVnhbmnk5q7kvDtfoo0jhhHblxgFyA3FLLImtA==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.8.tgz",
+      "integrity": "sha512-OAFbCTnGPtaIv0j+EZYzY20d+MD2JNbJ/YXZ4s0/oZlSg87bb0gjcIbccw2lnytipymZcZNr5ArFFeh0saGEwA==",
       "requires": {
         "@types/async": "2.0.50",
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.1.20",
+        "apollo-cache": "1.1.22",
         "apollo-link": "^1.0.0",
         "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "1.0.25",
+        "apollo-utilities": "1.0.27",
         "symbol-observable": "^1.0.2",
         "zen-observable": "^0.8.0"
       }
     },
     "apollo-datasource": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.2.0.tgz",
-      "integrity": "sha512-WJM9Ix3uogIfAG7mjL1NZQM9+45rcikn4mPWhE1Iuyw2+Y857J3uKJqQgF5h9Fg64SlCJh9u5WL3N7N5mg1fVw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.2.1.tgz",
+      "integrity": "sha512-r185+JTa5KuF1INeTAk7AEP76zwMN6c8Ph1lmpzJMNwBUEzTGnLClrccCskCBx4SxfnkdKbuQdwn9JwCJUWrdg==",
       "requires": {
-        "apollo-server-caching": "0.2.0",
+        "apollo-server-caching": "0.2.1",
         "apollo-server-env": "2.2.0"
       }
     },
     "apollo-engine-reporting": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.1.2.tgz",
-      "integrity": "sha512-W6zBTypI2ZLe9ZpMI4EasyXJP2WG8CpxYOU3Q4iuCKh8HYJqrQC5QVFXRF7TRBQTE6tc1seYnAHdgqv0ozxBrw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.2.0.tgz",
+      "integrity": "sha512-Q6FfVb10v/nrv8FaFsPjIYlWh62jaYav3LuMgM9PsHWGK/zRQFXOEwLxcY2UCvG7O1moxF3XGmfBhMgo54py+Q==",
       "requires": {
-        "apollo-engine-reporting-protobuf": "0.1.0",
+        "apollo-engine-reporting-protobuf": "0.2.0",
         "apollo-server-env": "2.2.0",
         "async-retry": "^1.2.1",
-        "graphql-extensions": "0.3.2",
+        "graphql-extensions": "0.4.0",
         "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.0.tgz",
+          "integrity": "sha512-8TUgIIUVpXWOcqq9RdmTSHUrhc3a/s+saKv9cCl8TYWHK9vyJIdea7ZaSKHGDthZNcsN+C3LulZYRL3Ah8ukoA==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.2.6"
+          }
+        }
       }
     },
     "apollo-engine-reporting-protobuf": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.1.0.tgz",
-      "integrity": "sha512-GReJtAYTmpwg0drb9VgFtqObYYTCHkJhlHEYCeXY8bJV4fOgXsAZ7CIXR9nPKO0mBaoHIHaGYvXGcyCLrZ36VA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.2.0.tgz",
+      "integrity": "sha512-qI+GJKN78UMJ9Aq/ORdiM2qymZ5yswem+/VDdVFocq+/e1QqxjnpKjQWISkswci5+WtpJl9SpHBNxG98uHDKkA==",
       "requires": {
         "protobufjs": "^6.8.6"
       }
     },
     "apollo-env": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.2.4.tgz",
-      "integrity": "sha512-pphNvrS7JmgvkvhaNEh+u0GpolytboAQcNbwmgskvX0VaLPfrrVox0AwHCteReB8t8s87NhbLd0VTG1nxmjFfQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.2.5.tgz",
+      "integrity": "sha512-Gc7TEbwCl7jJVutnn8TWfzNSkrrqyoo0DP92BQJFU9pZbJhpidoXf2Sw1YwOJl82rRKH3ujM3C8vdZLOgpFcFA==",
       "requires": {
         "core-js": "^3.0.0-beta.3",
         "node-fetch": "^2.2.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.0.0-beta.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0-beta.3.tgz",
-          "integrity": "sha512-kM/OfrnMThP5PwGAj5HhQLdjUqzjrllqN2EVnk/X9qrLsfYjR2hzZ+E/8CzH0xuosexZtqMTLQrk//BULrBj9w=="
+          "version": "3.0.0-beta.8",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.0-beta.8.tgz",
+          "integrity": "sha512-ex9wpitprNDuK6bPRljFW0z0IBatqtmqeuZ1HpcFcSkdOQSGNu3XdZSTshEuAIeYgLarHpw55P3SQlKAnXmpuQ=="
         },
         "node-fetch": {
           "version": "2.3.0",
@@ -1910,36 +1911,36 @@
       }
     },
     "apollo-link": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
-      "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.6.tgz",
+      "integrity": "sha512-sUNlA20nqIF3gG3F8eyMD+mO80fmf3dPZX+GUOs3MI9oZR8ug09H3F0UsWJMcpEg6h55Yy5wZ+BMmAjrbenF/Q==",
       "requires": {
         "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.10"
+        "zen-observable-ts": "^0.8.13"
       }
     },
     "apollo-link-context": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.9.tgz",
-      "integrity": "sha512-gcC1WH7mTyNtS0bF4fPijepXqnERwZjm1JCkuOT6ADBTpDTXIqK+Ec+/QkVawDO26EV9OX5ujWe4kI1qC6T6tA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.12.tgz",
+      "integrity": "sha512-gb4UptV9O6Kp3i5b2TlDEfPSL2LG//mTSb3zyuR5U2cAzu/huw98f1CCxcjUKTrlIMsQuE6G/hbaThDxnoIThQ==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.6"
       }
     },
     "apollo-link-dedup": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.10.tgz",
-      "integrity": "sha512-tpUI9lMZsidxdNygSY1FxflXEkUZnvKRkMUsXXuQUNoSLeNtEvUX7QtKRAl4k9ubLl8JKKc9X3L3onAFeGTK8w==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.13.tgz",
+      "integrity": "sha512-i4NuqT3DSFczFcC7NMUzmnYjKX7NggLY+rqYVf+kE9JjqKOQhT6wqhaWsVIABfIUGE/N0DTgYJBCMu/18aXmYA==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.6"
       }
     },
     "apollo-link-http-common": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.5.tgz",
-      "integrity": "sha512-6FV1wr5AqAyJ64Em1dq5hhGgiyxZE383VJQmhIoDVc3MyNcFL92TkhxREOs4rnH2a9X2iJMko7nodHSGLC6d8w==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.8.tgz",
+      "integrity": "sha512-gGmXZN8mr7e9zjopzKQfZ7IKnh8H12NxBDzvp9nXI3U82aCVb72p+plgoYLcpMY8w6krvoYjgicFmf8LO20TCQ==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.6"
       }
     },
     "apollo-link-persisted-queries": {
@@ -1961,42 +1962,57 @@
       }
     },
     "apollo-link-ws": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.9.tgz",
-      "integrity": "sha512-CtKwLE61bCJTW5jrucOMm5PubeAlCl/9i45pg4GKKlAbl0zR4i2dww8TJkYoIY6iCyj4qjKW/uqGD6v5/aVwhg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.12.tgz",
+      "integrity": "sha512-BjbskhfuuIgk9e4XHdrqmjxkY+RkD1tuerrs4PLiPTkJYcQrvA8t27lGBSrDUKHWH4esCdhQF1UhKPwhlouEHw==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.6"
       }
     },
     "apollo-server-caching": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.2.0.tgz",
-      "integrity": "sha512-/v7xWEcyyahs3hwX4baH/GekuHz3LRt9NoIYwg869G1eeqjuwY6NsowRIujZ100anJQwm9v5A9/sLtHBFvbgYg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.2.1.tgz",
+      "integrity": "sha512-+U9F3X297LL8Gqy6ypfDNEv/DfV/tDht9Dr2z3AMaEkNW1bwO6rmdDL01zYxDuVDVq6Z3qSiNCSO2pXE2F0zmA==",
       "requires": {
-        "lru-cache": "^4.1.3"
+        "lru-cache": "^5.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "apollo-server-core": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.2.2.tgz",
-      "integrity": "sha512-F6d4u5m1rJB4ucpLPGCoa9Dvo5OjGMIGdAzT9A35yOvlFWwvIR46jGmYmGmNp4Qx852rb1axSZVzNy7k/Dix0w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.3.1.tgz",
+      "integrity": "sha512-8jMWYOQIZi9mDJlHe2rXg8Cp4xKYogeRu23jkcNy+k5UjZL+eO+kHXbNFiTaP4HLYYEpe2XE3asxp6q5YUEQeQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.2.6",
-        "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "@types/ws": "^6.0.0",
-        "apollo-cache-control": "0.3.2",
-        "apollo-datasource": "0.2.0",
-        "apollo-engine-reporting": "0.1.2",
-        "apollo-server-caching": "0.2.0",
+        "apollo-cache-control": "0.4.0",
+        "apollo-datasource": "0.2.1",
+        "apollo-engine-reporting": "0.2.0",
+        "apollo-server-caching": "0.2.1",
         "apollo-server-env": "2.2.0",
         "apollo-server-errors": "2.2.0",
-        "apollo-server-plugin-base": "0.1.2",
-        "apollo-tracing": "0.3.2",
-        "graphql-extensions": "0.3.2",
+        "apollo-server-plugin-base": "0.2.1",
+        "apollo-tracing": "0.4.0",
+        "graphql-extensions": "0.4.1",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tag": "^2.9.2",
         "graphql-tools": "^4.0.0",
+        "graphql-upload": "^8.0.2",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.10",
         "subscriptions-transport-ws": "^0.9.11",
@@ -2025,18 +2041,17 @@
       "integrity": "sha512-gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg=="
     },
     "apollo-server-express": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.2.2.tgz",
-      "integrity": "sha512-DPxHOUd0Waztuix0r1ed6xfdlR7P7RzIXPmybhPXj1bZJtYHz5If0ngYNjtFqnXVrC8aSRtMz108SQUAnduYwA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.3.1.tgz",
+      "integrity": "sha512-J+rObr4GdT/5j6qTByUJoSvZSjTAX/7VqIkr2t+GxwcVUFGet2MdOHuV6rtWKc8CRgvVKfKN6iBrb2EOFcp2LQ==",
       "requires": {
-        "@apollographql/apollo-upload-server": "^5.0.3",
-        "@apollographql/graphql-playground-html": "^1.6.4",
+        "@apollographql/graphql-playground-html": "^1.6.6",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.0",
         "@types/cors": "^2.8.4",
         "@types/express": "4.16.0",
         "accepts": "^1.3.5",
-        "apollo-server-core": "2.2.2",
+        "apollo-server-core": "2.3.1",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
         "graphql-subscriptions": "^1.0.0",
@@ -2045,33 +2060,43 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.1.2.tgz",
-      "integrity": "sha512-+uicMcNctlP6YwIhzLLEycZzao/810OSzcxgPYKItXr5lGa1GuHD7sRIWldT3YoSdpw6Gal2lBuw6/DmnoDsPg=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.2.1.tgz",
+      "integrity": "sha512-497NIY9VWRYCrMSkgR11IrIUO4Fsy6aGgnpOJoTdLQAnkDD9SJDSRzwKj4gypUoTT2unfKDng4eMxXVZlHvjOw=="
     },
     "apollo-tracing": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.3.2.tgz",
-      "integrity": "sha512-YwN1m1k0JJsxGh0QWsEM3OLnyem0GT2tZnGeO2OogCr6dH5lE0SjKPc6UzpcI/3fPyxRrx5QvpUiP+DJeehhTA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.4.0.tgz",
+      "integrity": "sha512-BlM8iQUQva4fm0xD/pLwkcz0degfB9a/aAn4k4cK36eLVD8XUkl7ptEB0c+cwcj7tOYpV1r5QX1XwdayBzlHSg==",
       "requires": {
         "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.3.2"
+        "graphql-extensions": "0.4.0"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.0.tgz",
+          "integrity": "sha512-8TUgIIUVpXWOcqq9RdmTSHUrhc3a/s+saKv9cCl8TYWHK9vyJIdea7ZaSKHGDthZNcsN+C3LulZYRL3Ah8ukoA==",
+          "requires": {
+            "@apollographql/apollo-tools": "^0.2.6"
+          }
+        }
       }
     },
     "apollo-upload-client": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-9.1.0.tgz",
-      "integrity": "sha512-ZN5gsbBjImEZTWWTUHpCEGDasnoBGbaODpznQ5EawyNHceuFYSNJbbft+ZZ841vZAcj9XZdKUKoaLBlMZ/r7nw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-10.0.0.tgz",
+      "integrity": "sha512-N0SENiEkZXoY4nl9xxrXFcj/cL0AVkSNQ4aYXSaruCBWE0aKpK6aCe4DBmiEHrK3FAsMxZPEJxBRIWNbsXT8dw==",
       "requires": {
-        "apollo-link": "^1.2.3",
-        "apollo-link-http-common": "^0.2.5",
-        "extract-files": "^4.0.0"
+        "apollo-link": "^1.2.6",
+        "apollo-link-http-common": "^0.2.8",
+        "extract-files": "^5.0.0"
       }
     },
     "apollo-utilities": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.25.tgz",
-      "integrity": "sha512-AXvqkhni3Ir1ffm4SA1QzXn8k8I5BBl4PVKEyak734i4jFdp+xgfUyi2VCqF64TJlFTA/B73TRDUvO2D+tKtZg==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.27.tgz",
+      "integrity": "sha512-nzrMQ89JMpNmYnVGJ4t8zN75gQbql27UDhlxNi+3OModp0Masx5g+fQmQJ5B4w2dpRuYOsdwFLmj3lQbwOKV1Q==",
       "requires": {
         "fast-json-stable-stringify": "^2.0.0"
       }
@@ -2510,7 +2535,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -3000,12 +3025,11 @@
       "dev": true
     },
     "busboy": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.0.tgz",
+      "integrity": "sha512-e+kzZRAbbvJPLjQz2z+zAyr78BSi9IFeBTyLwF76g78Q2zRt/RZ1NtS3MS17v2yLqYfLz69zHdC+1L4ja8PwqQ==",
       "requires": {
-        "dicer": "0.2.5",
-        "readable-stream": "1.1.x"
+        "dicer": "0.3.0"
       }
     },
     "bytes": {
@@ -4043,7 +4067,8 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4582,7 +4607,8 @@
     "deepmerge": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "dev": true
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -4707,11 +4733,10 @@
       "dev": true
     },
     "dicer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
       "requires": {
-        "readable-stream": "1.1.x",
         "streamsearch": "0.1.2"
       }
     },
@@ -4816,9 +4841,9 @@
       }
     },
     "dotenv": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
-      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
       "dev": true
     },
     "dotgitignore": {
@@ -4845,7 +4870,8 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -5233,9 +5259,9 @@
       "dev": true
     },
     "eslint-plugin-node": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.0.tgz",
-      "integrity": "sha512-Y+ln8iQ52scz9+rSPnSWRaAxeWaoJZ4wIveDR0vLHkuSZGe44Vk1J4HX7WvEP5Cm+iXPE8ixo7OM7gAO3/OKpQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz",
+      "integrity": "sha512-ZjOjbjEi6jd82rIpFSgagv4CHWzG9xsQAVp1ZPlhRnnYxcTgENUVBvhYmkQ7GvT1QFijUSo69RaiOJKhMu6i8w==",
       "dev": true,
       "requires": {
         "eslint-plugin-es": "^1.3.1",
@@ -5267,12 +5293,12 @@
       "dev": true
     },
     "eslint-plugin-vue": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-4.7.1.tgz",
-      "integrity": "sha512-esETKhVMI7Vdli70Wt4bvAwnZBJeM0pxVX9Yb0wWKxdCJc2EADalVYK/q2FzMw8oKN0wPMdqVCKS8kmR89recA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.1.0.tgz",
+      "integrity": "sha512-C7avvbGLb9J1PyGiFolPcGR4ljUc+dKm5ZJdrUKXwXFxHHx4SqOmRI29AsFyW7PbCGcnOvIlaq7NJS6HDIak+g==",
       "dev": true,
       "requires": {
-        "vue-eslint-parser": "^2.0.3"
+        "vue-eslint-parser": "^4.0.2"
       }
     },
     "eslint-scope": {
@@ -5353,21 +5379,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
     },
     "eventemitter3": {
       "version": "3.1.0",
@@ -5662,9 +5673,9 @@
       }
     },
     "extract-files": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-4.1.0.tgz",
-      "integrity": "sha512-2gjdb3dVzr1ie9+K8pupPTnsNkK4qmzbTFOIxghiWoh6nCTajGCGC72ZNYX0nBWy5IOq1FXfRVgvkkLqqE4sdw=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-5.0.0.tgz",
+      "integrity": "sha512-mTMXDGagB142JLMIbGRc11sNLPuN6G8qj5lRMx9T41Fkt3ot0OPkehcsLw05uT98LGEae2A1wFFDMkY4VEpbqg=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -5849,11 +5860,6 @@
         "write": "^0.2.1"
       }
     },
-    "flatmap-stream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.2.tgz",
-      "integrity": "sha512-ucyr6WkLXjyMuHPtOUq4l+nSAxgWi7v4QO508eQ9resnGj+lSup26oIsUI5aH8k4Qfpjsxa8dDf9UCKkS2KHzQ=="
-    },
     "flatten": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -5951,11 +5957,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -6006,6 +6007,11 @@
       "requires": {
         "null-check": "^1.0.0"
       }
+    },
+    "fs-capacitor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-1.0.1.tgz",
+      "integrity": "sha512-XdZK0Q78WP29Vm3FGgJRhRhrBm51PagovzWtW2kJ3Q6cYJbGtZqWSGTSPwvtEkyjIirFd7b8Yes/dpOYjt4RRQ=="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -6827,7 +6833,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -6845,7 +6851,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         }
       }
@@ -6864,17 +6870,17 @@
       }
     },
     "graphql-anywhere": {
-      "version": "4.1.22",
-      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.22.tgz",
-      "integrity": "sha512-qm2/1cKM8nfotxDhm4J0r1znVlK0Yge/yEKt26EVVBgpIhvxjXYFALCGbr7cvfDlvzal1iSPpaYa+8YTtjsxQA==",
+      "version": "4.1.24",
+      "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.24.tgz",
+      "integrity": "sha512-g81K7FqXSF3q1iqFWlwiwD+g0SDkPUUa9+Wa+7BOrAe5+7R4BdNWL4dw9BRsJxt0Xx6nOaI2E+VM7QMAucQFvA==",
       "requires": {
-        "apollo-utilities": "^1.0.25"
+        "apollo-utilities": "^1.0.27"
       }
     },
     "graphql-extensions": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.3.2.tgz",
-      "integrity": "sha512-eIAWwtZNlUAHtHF6uNP6+4M+GCksqUYfNBxW5rTAlCB4/ZcuIvchVtN1CgVM7MooW3akPM1Eci11WyeXvgOugQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.1.tgz",
+      "integrity": "sha512-Xei4rBxbsTHU6dYiq9y1xxbpRMU3+Os7yD3vXV5W4HbTaxRMizDmu6LAvV4oBEi0ttwICHARQjYTjDTDhHnxrQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.2.6"
       }
@@ -6902,6 +6908,31 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
+      }
+    },
+    "graphql-upload": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.3.tgz",
+      "integrity": "sha512-Wh+Ug8ezLz7zMuLkatM627taNpWdPgyWzZiSXAvgotx27Z15VGhlSVB6BslBfyP8uHJJPdUNXhXDg4Z1a+/UIA==",
+      "requires": {
+        "busboy": "^0.3.0",
+        "fs-capacitor": "^1.0.0",
+        "http-errors": "^1.7.1",
+        "object-path": "^0.11.4"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
+          "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        }
       }
     },
     "growly": {
@@ -7823,7 +7854,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -9313,11 +9345,6 @@
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9921,20 +9948,20 @@
       }
     },
     "nodemon": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.6.tgz",
-      "integrity": "sha512-4pHQNYEZun+IkIC2jCaXEhkZnfA7rQe73i8RkdRyDJls/K+WxR7IpI5uNUsAvQ0zWvYcCDNGD+XVtw2ZG86/uQ==",
+      "version": "1.18.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.9.tgz",
+      "integrity": "sha512-oj/eEVTEI47pzYAjGkpcNw0xYwTl4XSTUQv2NPQI6PpN3b75PhpuYk3Vb3U80xHCyM2Jm+1j68ULHXl4OR3Afw==",
       "requires": {
         "chokidar": "^2.0.4",
         "debug": "^3.1.0",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.0",
+        "pstree.remy": "^1.1.6",
         "semver": "^5.5.0",
         "supports-color": "^5.2.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.2",
-        "update-notifier": "^2.3.0"
+        "update-notifier": "^2.5.0"
       },
       "dependencies": {
         "debug": {
@@ -10293,7 +10320,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -10537,14 +10564,6 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
-      }
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -11665,14 +11684,6 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
-    "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "requires": {
-        "event-stream": "~3.3.0"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -11685,12 +11696,9 @@
       "dev": true
     },
     "pstree.remy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
-      "integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
-      "requires": {
-        "ps-tree": "^1.1.0"
-      }
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -11901,6 +11909,7 @@
       "version": "1.1.14",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -11984,7 +11993,8 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.13.3",
@@ -12748,9 +12758,9 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -12774,15 +12784,16 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
       "requires": {
         "through": "2"
       }
@@ -13072,15 +13083,6 @@
         }
       }
     },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
-      }
-    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -13169,7 +13171,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -13682,7 +13685,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -13816,6 +13820,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "toposort": {
       "version": "1.0.7",
@@ -14350,96 +14359,60 @@
       }
     },
     "vue-cli-plugin-apollo": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.18.0.tgz",
-      "integrity": "sha512-G18uONXpSDXdDVJo7lrYAUrVN7fK4Py3BXdesNNuFQRIMI0mUdWoXI8IdomtHYr9XevAilx4j8ZYylqJLqv8dA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/vue-cli-plugin-apollo/-/vue-cli-plugin-apollo-0.19.1.tgz",
+      "integrity": "sha512-GVXCamuTmT7EpTFJHUNR48Lbg1Y+ZnED1fQ6nveTqAf7VCSADswJyX75gYrJSjWUP4N3BJqzT/O/JVWJfB1G2Q==",
       "requires": {
-        "apollo-cache-inmemory": "^1.3.9",
-        "apollo-client": "^2.4.5",
-        "apollo-link": "^1.2.3",
-        "apollo-link-context": "^1.0.9",
-        "apollo-link-persisted-queries": "^0.2.1",
+        "apollo-cache-inmemory": "^1.3.12",
+        "apollo-client": "^2.4.8",
+        "apollo-link": "^1.2.6",
+        "apollo-link-context": "^1.0.12",
+        "apollo-link-persisted-queries": "^0.2.2",
         "apollo-link-state": "^0.4.2",
-        "apollo-link-ws": "^1.0.9",
-        "apollo-server-express": "^2.2.0",
-        "apollo-upload-client": "^9.1.0",
-        "apollo-utilities": "^1.0.25",
+        "apollo-link-ws": "^1.0.12",
+        "apollo-server-express": "^2.3.1",
+        "apollo-upload-client": "^10.0.0",
+        "apollo-utilities": "^1.0.27",
         "chalk": "^2.4.1",
-        "deepmerge": "^2.2.1",
+        "deepmerge": "^3.0.0",
         "esm": "^3.0.84",
         "execa": "^1.0.0",
         "express": "^4.16.4",
         "graphql": "^14.0.2",
         "graphql-subscriptions": "^1.0.0",
-        "nodemon": "^1.18.6",
+        "nodemon": "^1.18.9",
         "subscriptions-transport-ws": "^0.9.15",
         "ts-node": "^7.0.1"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.0.0.tgz",
+          "integrity": "sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw=="
+        }
       }
     },
     "vue-eslint-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
-      "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-4.0.3.tgz",
+      "integrity": "sha512-AUeQsYdO6+7QXCems+WvGlrXd37PHv/zcRQSQdY1xdOMwdFAPEnMBsv7zPvk0TPGulXkK/5p/ITgrjiYB7k3ag==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "eslint-scope": "^3.7.1",
+        "debug": "^4.1.0",
+        "eslint-scope": "^4.0.0",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.2",
-        "esquery": "^1.0.0",
-        "lodash": "^4.17.4"
+        "espree": "^4.1.0",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.11"
       },
       "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "dev": true,
-          "requires": {
-            "acorn": "^3.0.4"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-              "dev": true
-            }
-          }
-        },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "eslint-scope": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-          "dev": true,
-          "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
           }
         },
         "ms": {
@@ -15033,7 +15006,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
@@ -15082,9 +15055,9 @@
       "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ=="
     },
     "zen-observable-ts": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz",
-      "integrity": "sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.13.tgz",
+      "integrity": "sha512-WDb8SM0tHCb6c0l1k60qXWlm1ok3zN9U4VkLdnBKQwIYwUoB9psH7LIFgR+JVCCMmBxUgOjskIid8/N02k/2Bg==",
       "requires": {
         "zen-observable": "^0.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
     "vue-apollo": "^3.0.0-beta.26",
-    "vue-cli-plugin-apollo": "^0.18.0"
+    "vue-cli-plugin-apollo": "^0.19.1"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.3.10"


### PR DESCRIPTION
After running my app in production with Nuxt pre-major version `0.10.7` for almost a year, I recently found the time to upgrade to Nuxt 2. I like the new module architecture, but I was facing some difficulties with my existing JWT authentication flow, with the server giving me 401ers because the module was using expired JWT token.

Most parts of my app without any authentication, without any `Authentication` header being set. But if an expired token would be used, the backend gives me an expected 401. Before I was checking the expiration timestamp of the JWT in a network middleware in order to use it only, when the token was valid.

To make my expiration check work with the module, I added a `validateToken` configuration parameter which expects a function that takes a token as input and returns a boolean whether this token is valid.

I thought this might be helpful for others using a similar flow with JWT.

Here is how I integrated it:

```
// ./plugins/apollo-config.js
import jwtDecode from 'jwt-decode'

const isUpToDate = (jwt) => {
  const exp = jwt['exp']
  if (exp) {
    const expMs = exp * 1000
    const in30Secs = Date.now() + 30 * 1000
    return new Date(expMs) > new Date(in30Secs)
  } else {
    return true
  }
}

const validateJwtToken = (token) => {
  const decoded = jwtDecode(token)
  if (decoded) {
    return isUpToDate(decoded)
  } else {
    return false
  }
}

export default function(context) {
  return {
    httpEndpoint: `${apiHost}/graphql`,
    httpLinkOptions: {
      credentials: 'same-origin'
    },
    validateToken: validateJwtToken
  }
}

// nuxt.config.js
apollo: {
    // ...
    clientConfigs: {
      default: '~/plugins/apollo-config'
    }
}
```