### PR TITLE
feat: support js-cookie attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Once the setup is completed you have a successfully enabled `vue-apollo` in your
 You have following methods for authentication available:
 ```js
  // set your graphql-token
- this.$apolloHelpers.onLogin(token /* if not default you can pass in client as second argument, and you can set custom token expiration on third argument */)
+ this.$apolloHelpers.onLogin(token /* if not default you can pass in client as second argument, and you can set the custom attributes object as the third argument */)
  // unset your graphql-token
  this.$apolloHelpers.onLogout(/* if not default you can pass in client as second argument */)
  // get your current token (we persist token in a cookie)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,30 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
   // Give apollo module options
   apollo: {
     tokenName: 'yourApolloTokenName', // optional, default: apollo-token
-    tokenExpires: 10, // optional, default: 7 (days)
+    cookieAttributes: {
+      /**
+        * Define when the cookie will be removed. Value can be a Number
+        * which will be interpreted as days from time of creation or a
+        * Date instance. If omitted, the cookie becomes a session cookie.
+        */
+      expires: 7, // optional, default: 7 (days)
+
+      /**
+        * Define the path where the cookie is available. Defaults to '/'
+        */
+      path: '/', // optional
+      /**
+        * Define the domain where the cookie is available. Defaults to
+        * the domain of the page where the cookie was created.
+        */
+      domain: 'example.com', // optional
+
+      /**
+        * A Boolean indicating if the cookie transmission requires a
+        * secure protocol (https). Defaults to false.
+        */
+      secure: false,
+    },
     includeNodeModules: true, // optional, default: false (this includes graphql-tag for node_modules folder)
     authenticationType: 'Basic', // optional, default: 'Bearer'
     // optional

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Once the setup is completed you have a successfully enabled `vue-apollo` in your
 You have following methods for authentication available:
 ```js
  // set your graphql-token
- this.$apolloHelpers.onLogin(token /* if not default you can pass in client as second argument, and you can set the custom attributes object as the third argument */)
+ this.$apolloHelpers.onLogin(token /* if not default you can pass in client as second argument, and you can set custom cookies attributes object as the third argument */)
  // unset your graphql-token
  this.$apolloHelpers.onLogout(/* if not default you can pass in client as second argument */)
  // get your current token (we persist token in a cookie)

--- a/lib/module.js
+++ b/lib/module.js
@@ -32,6 +32,10 @@ module.exports = function (moduleOptions) {
 
   options.tokenName = options.tokenName || 'apollo-token'
   options.cookieAttributes = options.cookieAttributes || { expires: 7, path: '/', secure: false }
+
+  // Fallback for tokenExpiry
+  if (typeof options.tokenExpiry === 'number') Object.assign(options.cookieAttributes, { expires: options.tokenExpiry })
+
   options.authenticationType = options.authenticationType === undefined ? 'Bearer' : options.authenticationType
 
   if (options.errorHandler !== undefined && typeof options.errorHandler !== 'function') {

--- a/lib/module.js
+++ b/lib/module.js
@@ -31,7 +31,7 @@ module.exports = function (moduleOptions) {
   })
 
   options.tokenName = options.tokenName || 'apollo-token'
-  options.tokenExpires = options.tokenExpires || 7
+  options.cookieAttributes = options.cookieAttributes || { expires: 7, path: '/', secure: false }
   options.authenticationType = options.authenticationType === undefined ? 'Bearer' : options.authenticationType
 
   if (options.errorHandler !== undefined && typeof options.errorHandler !== 'function') {

--- a/lib/module.js
+++ b/lib/module.js
@@ -33,8 +33,11 @@ module.exports = function (moduleOptions) {
   options.tokenName = options.tokenName || 'apollo-token'
   options.cookieAttributes = options.cookieAttributes || { expires: 7, path: '/', secure: false }
 
-  // Fallback for tokenExpiry
-  if (typeof options.tokenExpiry === 'number') Object.assign(options.cookieAttributes, { expires: options.tokenExpiry })
+  // Fallback for tokenExpires
+  if (typeof options.tokenExpires === 'number') {
+    console.warn('Deprecation warning: tokenExpires will no longer be supported in the next releases, use the cookieAttributes configuration instead.')
+    Object.assign(options.cookieAttributes, { expires: options.tokenExpires })
+  }
 
   options.authenticationType = options.authenticationType === undefined ? 'Bearer' : options.authenticationType
 

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -12,7 +12,7 @@ export default (ctx, inject) => {
   const providerOptions = { clients: {} }
   const { app, beforeNuxtRender, req } = ctx
   const AUTH_TOKEN_NAME = '<%= options.tokenName %>'
-  const AUTH_TOKEN_EXPIRES = <%= options.tokenExpires %>
+  const COOKIE_ATTRIBUTES = '<%= options.cookieAttributes %>'
   const AUTH_TYPE = '<%= options.authenticationType %> '
 
   // Config
@@ -25,7 +25,7 @@ export default (ctx, inject) => {
           const cookies = cookie.parse((req && req.headers.cookie) || '')
           token = cookies[<%= key %>TokenName]
         } else {
-          token = jsCookie.get(<%= key %>TokenName)
+          token = jsCookie.get(<%= key %>TokenName, COOKIE_ATTRIBUTES)
         }
         return token && <%= key %>ClientConfig.validateToken(token) ? AUTH_TYPE + token : ''
       }
@@ -99,11 +99,11 @@ export default (ctx, inject) => {
   }
 
   inject('apolloHelpers', {
-    onLogin: async (token, apolloClient = apolloProvider.defaultClient, tokenExpires = AUTH_TOKEN_EXPIRES) => {
+    onLogin: async (token, apolloClient = apolloProvider.defaultClient, cookieAttributes = COOKIE_ATTRIBUTES) => {
       if (token) {
-        jsCookie.set(AUTH_TOKEN_NAME, token, { expires: tokenExpires })
+        jsCookie.set(AUTH_TOKEN_NAME, token, cookieAttributes)
       } else {
-        jsCookie.remove(AUTH_TOKEN_NAME)
+        jsCookie.remove(AUTH_TOKEN_NAME, cookieAttributes)
       }
       if (apolloClient.wsClient) restartWebsockets(apolloClient.wsClient)
       try {
@@ -114,7 +114,7 @@ export default (ctx, inject) => {
       }
     },
     onLogout: async (apolloClient = apolloProvider.defaultClient) => {
-        jsCookie.remove(AUTH_TOKEN_NAME)
+        jsCookie.remove(AUTH_TOKEN_NAME, COOKIE_ATTRIBUTES)
         if (apolloClient.wsClient) restartWebsockets(apolloClient.wsClient)
         try {
             await apolloClient.resetStore()
@@ -128,7 +128,7 @@ export default (ctx, inject) => {
             const cookies = cookie.parse((req && req.headers.cookie) || '')
             return cookies && cookies[tokenName]
         }
-        return jsCookie.get(tokenName)
+        return jsCookie.get(tokenName, COOKIE_ATTRIBUTES)
     }
   })
 }

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -18,6 +18,7 @@ export default (ctx, inject) => {
   // Config
   <% Object.keys(options.clientConfigs).forEach((key) => { %>
       const <%= key %>TokenName = '<%= options.clientConfigs[key].tokenName %>'  || AUTH_TOKEN_NAME
+      const <%= key %>CookieAttributes = '<%= options.clientConfigs[key].cookieAttributes %>'  || COOKIE_ATTRIBUTES
 
       function <%= key %>GetAuth () {
         let token
@@ -25,7 +26,7 @@ export default (ctx, inject) => {
           const cookies = cookie.parse((req && req.headers.cookie) || '')
           token = cookies[<%= key %>TokenName]
         } else {
-          token = jsCookie.get(<%= key %>TokenName, COOKIE_ATTRIBUTES)
+          token = jsCookie.get(<%= key %>TokenName, <%= key %>CookieAttributes)
         }
         return token && <%= key %>ClientConfig.validateToken(token) ? AUTH_TYPE + token : ''
       }
@@ -63,6 +64,7 @@ export default (ctx, inject) => {
       <%= key %>ClientConfig.ssr = !!process.server
       <%= key %>ClientConfig.cache = <%= key %>Cache
       <%= key %>ClientConfig.tokenName = <%= key %>TokenName
+      <%= key %>ClientConfig.cookieAttributes = <%= key %>CookieAttributes
 
       // Create apollo client
       let <%= key %>ApolloCreation = createApolloClient({

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -105,6 +105,9 @@ export default (ctx, inject) => {
 
   inject('apolloHelpers', {
     onLogin: async (token, apolloClient = apolloProvider.defaultClient, cookieAttributes = COOKIE_ATTRIBUTES) => {
+      // Fallback for tokenExpires param
+      if (typeof cookieAttributes === 'number') cookieAttributes = { expires: cookieAttributes }
+
       if (token) {
         jsCookie.set(AUTH_TOKEN_NAME, token, cookieAttributes)
       } else {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/core": "latest",
     "@babel/preset-env": "latest",
     "@types/graphql": "^14.0.7",
+    "@types/js-cookie": "^2.2.1",
     "codecov": "latest",
     "core-js": "^2.6.4",
     "dotenv": "latest",

--- a/test/fixture/pages/index.vue
+++ b/test/fixture/pages/index.vue
@@ -69,7 +69,7 @@
                         mutation: authenticateUserGql,
                         variables: credentials
                     }).then(({data}) => data && data.authenticateUser)
-                    await this.$apolloHelpers.onLogin(res.token, undefined, 7)
+                    await this.$apolloHelpers.onLogin(res.token, undefined, { expires: 7 })
                     this.successfulData = res
                     this.isAuthenticated = true
                 } catch (e) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,8 +8,7 @@ export interface ApolloHelpers {
   onLogin(
     token: string,
     apolloClient?: ApolloClient<any>,
-    tokenExpires?: number,
-    cookieAttributes?: CookieAttributes
+    cookieAttributes?: number | CookieAttributes
   ): Promise<void>;
   onLogout(apolloClient?: ApolloClient<any>): Promise<void>;
   getToken(tokenName?: string): string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,8 @@
-import ApolloClient from 'apollo-client';
-import { CookieAttributes } from 'js-cookie';
+import ApolloClient from 'apollo-client'
+import { CookieAttributes } from 'js-cookie'
 
-import './vue';
-import './nuxt';
+import './vue'
+import './nuxt'
 
 export interface ApolloHelpers {
   onLogin(

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -11,15 +11,15 @@ const apolloClient = new ApolloClient({
 
 const tokenName = 'foo'
 const token = 'bar'
-const tokenExpires = 1
+const cookieAttributes = { expires: 2, path: '/', secure: false }
 
 // onLogin
 
 async () => {
   await vm.$apolloHelpers.onLogin(token)
   await vm.$apolloHelpers.onLogin(token, apolloClient)
-  await vm.$apolloHelpers.onLogin(token, apolloClient, tokenExpires)
-  await vm.$apolloHelpers.onLogin(token, undefined, tokenExpires)
+  await vm.$apolloHelpers.onLogin(token, apolloClient, cookieAttributes)
+  await vm.$apolloHelpers.onLogin(token, undefined, cookieAttributes)
 }
 
 // onLogout

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -12,7 +12,7 @@ declare module 'vue/types/vue' {
       onLogin(
         token: string,
         apolloClient?: ApolloClient<{}>,
-        attributes?: CookieAttributes
+        cookieAttributes?: CookieAttributes
       ): Promise<void>;
       onLogout(apolloClient?: ApolloClient<{}>): Promise<void>;
       getToken(tokenName?: string): string;

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -2,15 +2,20 @@
  * Extends interfaces in Vue.js
  */
 
-import Vue from 'vue'
-import { ApolloClient } from 'apollo-client'
+import Vue from 'vue';
+import { ApolloClient } from 'apollo-client';
+import { CookieAttributes } from 'js-cookie';
 
 declare module 'vue/types/vue' {
   interface Vue {
     $apolloHelpers: {
-      onLogin (token: string, apolloClient?: ApolloClient<{}>, tokenExpires?: number): Promise<void>
-      onLogout (apolloClient?: ApolloClient<{}>): Promise<void>
-      getToken (tokenName?: string): string
-    }
+      onLogin(
+        token: string,
+        apolloClient?: ApolloClient<{}>,
+        attributes?: CookieAttributes
+      ): Promise<void>;
+      onLogout(apolloClient?: ApolloClient<{}>): Promise<void>;
+      getToken(tokenName?: string): string;
+    };
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -2,12 +2,12 @@
  * Extends interfaces in Vue.js
  */
 
-import Vue from 'vue';
-import { ApolloClient } from 'apollo-client';
-import { ApolloHelpers } from '.';
+import Vue from 'vue'
+import { ApolloClient } from 'apollo-client'
+import { ApolloHelpers } from '.'
 
 declare module 'vue/types/vue' {
   interface Vue {
-    $apolloHelpers: ApolloHelpers;
+    $apolloHelpers: ApolloHelpers
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,6 +1020,11 @@
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.7.tgz#daa09397220a68ce1cbb3f76a315ff3cd92312f6"
   integrity sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ==
 
+"@types/js-cookie@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.1.tgz#aa6f6d5e5aaf7d97959e9fa938ac2501cf1a76f4"
+  integrity sha512-VIVurImEhQ95jxtjs8baVU5qCzVfwYfuMrpXwdRykJ5MCI5iY7/jB4cDSgwBVeYqeXrhT7GfJUwoDOmN0OMVCA==
+
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"


### PR DESCRIPTION
Introduces cookie Attributes support from the `js-cookie` package.

Unfortunately, it also introduces a breaking change for the `tokenExpiry` option.