### PR TITLE
Extend error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
       },
     },
     // optional
-    errorHandler '~/plugins/apollo-error-handler.js',
+    errorHandler: '~/plugins/apollo-error-handler.js',
     // required
     clientConfigs: {
       default: {

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
       },
     },
     // optional
-    errorHandler (error) {
-      console.log('%cError', 'background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;', error.message)
-    },
+    errorHandler '~/plugins/apollo-error-handler.js',
     // required
     clientConfigs: {
       default: {
@@ -90,6 +88,15 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
     }
   }
 }
+```
+
+```js
+// plugins/apollo-error-handler.js
+export default (error, context) => {
+  console.log(error)
+  context.error({ statusCode: 304, message: 'Server error' })
+}
+
 ```
 
 ```js

--- a/lib/module.js
+++ b/lib/module.js
@@ -35,7 +35,7 @@ module.exports = function (moduleOptions) {
   options.authenticationType = options.authenticationType === undefined ? 'Bearer' : options.authenticationType
 
   if (options.errorHandler !== undefined && typeof options.errorHandler !== 'string') {
-    throw new Error(`[Apollo module] errorHandler should be a path to an exported Apollo Client config.`)
+    throw new Error(`[Apollo module] errorHandler should be a path to an exported error handler config.`)
   }
   if (options.defaultOptions !== undefined && typeof options.defaultOptions !== 'object') {
     throw new Error(`[Apollo module] defaultOptions must be a object.`)

--- a/lib/module.js
+++ b/lib/module.js
@@ -34,8 +34,9 @@ module.exports = function (moduleOptions) {
   options.tokenExpires = options.tokenExpires || 7
   options.authenticationType = options.authenticationType === undefined ? 'Bearer' : options.authenticationType
 
-  if (options.errorHandler !== undefined && typeof options.errorHandler !== 'function') {
-    throw new Error(`[Apollo module] errorHandler must be a function.`)
+  if (options.errorHandler !== undefined && typeof options.errorHandler !== 'string') {
+    console.log(typeof options.errorHandler)
+    throw new Error(`[Apollo module] errorHandler should be a path to an exported Apollo Client config.`)
   }
   if (options.defaultOptions !== undefined && typeof options.defaultOptions !== 'object') {
     throw new Error(`[Apollo module] defaultOptions must be a object.`)

--- a/lib/module.js
+++ b/lib/module.js
@@ -35,7 +35,6 @@ module.exports = function (moduleOptions) {
   options.authenticationType = options.authenticationType === undefined ? 'Bearer' : options.authenticationType
 
   if (options.errorHandler !== undefined && typeof options.errorHandler !== 'string') {
-    console.log(typeof options.errorHandler)
     throw new Error(`[Apollo module] errorHandler should be a path to an exported Apollo Client config.`)
   }
   if (options.defaultOptions !== undefined && typeof options.defaultOptions !== 'object') {

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -81,13 +81,13 @@ export default (ctx, inject) => {
       <% if (options.defaultOptions) { %>
         defaultOptions: <%= JSON.stringify(options.defaultOptions) %>,
       <% } %>
-      <% if (options.errorHandler) { %>
-        <%= options.errorHandler %>
-      <% } else { %>
-        errorHandler (error) {
+      errorHandler (error) {
+        <% if (options.errorHandler) { %>
+          require('<%= options.errorHandler %>').default(error, ctx)
+        <% } else { %>
           console.log('%cError', 'background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;', error.message)
-        }
-      <% } %>
+        <% } %>
+      }
   })
 
   const apolloProvider = new VueApollo(vueApolloOptions)

--- a/test/fixture/apollo/customErrorHandler.js
+++ b/test/fixture/apollo/customErrorHandler.js
@@ -1,0 +1,4 @@
+export default (err, { error }) => {
+  console.log(err)
+  error({ statusCode: 304, message: 'Server error!' })
+}

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -12,6 +12,7 @@ module.exports = {
     title: 'Demo Page of apollo module'
   },
   modules: [['@@', {
+    errorHandler: '~/apollo/customErrorHandler.js',
     clientConfigs: {
       default: {
         httpEndpoint: process.env.HTTP_ENDPOINT,

--- a/test/fixture/pages/error-page.vue
+++ b/test/fixture/pages/error-page.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <pre>{{ allUsers }}</pre>
+    </div>
+</template>
+
+<script>
+import gql from 'graphql-tag'
+
+export default {
+    head () {
+        return {
+            title: 'Error Page'
+        }
+    },
+    data () {
+        return {
+            allUsers: []
+        }
+    },
+    apollo: {
+        allUsers: {
+            query: gql`{
+                allUsers {
+                    id
+                    dasdsa
+                }
+            }`
+        }
+    }
+}
+</script>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -23,4 +23,10 @@ describe('basic', () => {
     let html = await get('/')
     expect(html).toContain('This is the landing page')
   })
+
+  test('render', async () => {
+    await get('/error-page').catch(e =>
+      expect(e.statusCode).toEqual(304)
+    )
+  })
 })


### PR DESCRIPTION
Breaking change errorHandler option:
- fix (https://github.com/nuxt-community/apollo-module/issues/213)
- add nuxt context to errorHandler
- add test

Now errrorHandler require a path instead of a direct function
```js
{
  apollo: {
  ...
    errorHandler: '~/plugins/apollo-error-handler.js',
  }
}
```


 ```js
// plugins/apollo-error-handler.js
export default (error, context) => {
  console.log(error)
  context.error({ statusCode: 304, message: 'Server error' })
}
 ```