### PR TITLE
if our connecting client's req has headers.cookie, pass it in when SSR

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -64,6 +64,10 @@ export default (ctx, inject) => {
       <%= key %>ClientConfig.cache = <%= key %>Cache
       <%= key %>ClientConfig.tokenName = <%= key %>TokenName
 
+      // if ssr we'd still like to have our webclient's cookies
+      if (process.server && req && req.headers && req.headers.cookie)
+        <%= key %>ClientConfig.httpLinkOptions.headers={cookie:req.headers.cookie}
+
       // Create apollo client
       let <%= key %>ApolloCreation = createApolloClient({
         ...<%= key %>ClientConfig

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -63,7 +63,10 @@ export default (ctx, inject) => {
       <%= key %>ClientConfig.ssr = !!process.server
       <%= key %>ClientConfig.cache = <%= key %>Cache
       <%= key %>ClientConfig.tokenName = <%= key %>TokenName
-
+      
+      // if ssr we'd still like to have our webclient's cookies
+      if (process.server && req && req.headers && req.headers.cookie)
+        <%= key %>ClientConfig.httpLinkOptions.headers={cookie:req.headers.cookie}
 
       // Create apollo client
       let <%= key %>ApolloCreation = createApolloClient({

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -64,9 +64,6 @@ export default (ctx, inject) => {
       <%= key %>ClientConfig.cache = <%= key %>Cache
       <%= key %>ClientConfig.tokenName = <%= key %>TokenName
 
-      // if ssr we'd still like to have our webclient's cookies
-      if (process.server && req && req.headers && req.headers.cookie)
-        <%= key %>ClientConfig.httpLinkOptions.headers={cookie:req.headers.cookie}
 
       // Create apollo client
       let <%= key %>ApolloCreation = createApolloClient({


### PR DESCRIPTION
I've come across this issue when using nuxt-apollo-express-session. Most interactions issued from the browsers' apollo-client have the session cookie attached, per the browser, but when a Vue template is SSR pre-rendered, the apollo server(postgraphile in my case, one word: WOW) request did not have the cookie set. It was annoying because I'm using express-sessions with 

saveUninitialized: true 

and it would result in a bunch of spurious sessions.

So the solution is the following:
if our connecting client's req has headers.cookie, pass it to our httpLink.