### PR TITLE
Add nuxt configuration types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cookie": "^0.4.0",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.2.0",
-    "vue-apollo": "^3.0.0-beta.30",
+    "vue-apollo": "^3.0.0-rc.1",
     "vue-cli-plugin-apollo": "^0.20.0",
     "webpack-node-externals": "^1.7.2"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,2 @@
 import './vue'
+import './nuxt'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,14 @@
+import ApolloClient from 'apollo-client'
+
 import './vue'
 import './nuxt'
+
+export interface ApolloHelpers {
+  onLogin(
+    token: string,
+    apolloClient?: ApolloClient<any>,
+    tokenExpires?: number
+  ): Promise<void>
+  onLogout(apolloClient?: ApolloClient<any>): Promise<void>
+  getToken(tokenName?: string): string
+}

--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -5,10 +5,12 @@
 import NuxtConfiguration from '@nuxt/config'
 import { VueApolloOptions } from 'vue-apollo/types/options'
 import { ApolloClientClientConfig } from 'vue-cli-plugin-apollo/graphql-client'
+import Vue, { ComponentOptions } from 'vue'
+import { ApolloHelpers } from '.'
 
 declare module '@nuxt/config/types/index' {
   interface ApolloClientConfig extends ApolloClientClientConfig<any> {
-    httpEndpoint: string;
+    httpEndpoint: string
   }
 
   export default interface NuxtConfiguration {
@@ -24,5 +26,11 @@ declare module '@nuxt/config/types/index' {
         [key: string]: ApolloClientConfig | string
       }
     }
+  }
+}
+
+declare module '@nuxt/vue-app/types/index' {
+  interface NuxtAppOptions extends ComponentOptions<Vue> {
+    $apolloHelpers: ApolloHelpers
   }
 }

--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Extends interfaces in Nuxt
+ */
+
+import NuxtConfiguration from '@nuxt/config'
+import { VueApolloOptions } from 'vue-apollo/types/options'
+import { ApolloClientClientConfig } from 'vue-cli-plugin-apollo/graphql-client'
+
+declare module '@nuxt/config/types/index' {
+  interface ApolloClientConfig extends ApolloClientClientConfig<any> {
+    httpEndpoint: string;
+  }
+
+  export default interface NuxtConfiguration {
+    apollo: {
+      tokenName?: string
+      tokenExpires?: number
+      includeNodeModules?: boolean
+      authenticationType?: string
+      errorHandler?: string
+      defaultOptions?: VueApolloOptions<any>
+      clientConfigs: {
+        default: ApolloClientConfig | string
+        [key: string]: ApolloClientConfig | string
+      }
+    }
+  }
+}

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { ApolloClient } from 'apollo-client'
 import NuxtConfiguration from '@nuxt/config'
+import { Middleware } from '@nuxt/vue-app'
 import * as types from '../index'
 
 const vm = new Vue()
@@ -48,6 +49,11 @@ const config: NuxtConfiguration = {
       test2: '~/plugins/my-alternative-apollo-config.js'
     }
   }
+}
+
+// Nuxt Context
+const middleware: Middleware = ({ app }): void => {
+  app.$apolloHelpers.getToken()
 }
 
 // onLogin

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import { ApolloClient } from 'apollo-client'
+import NuxtConfiguration from '@nuxt/config'
 import * as types from '../index'
 
 const vm = new Vue()
@@ -12,6 +13,42 @@ const apolloClient = new ApolloClient({
 const tokenName = 'foo'
 const token = 'bar'
 const tokenExpires = 1
+
+// Nuxt config
+
+const config: NuxtConfiguration = {
+  apollo: {
+    tokenName: 'yourApolloTokenName',
+    tokenExpires: 10,
+    includeNodeModules: true,
+    authenticationType: 'Basic',
+    defaultOptions: {
+      $query: {
+        loadingKey: 'loading',
+        fetchPolicy: 'cache-and-network'
+      }
+    },
+    errorHandler: '~/plugins/apollo-error-handler.js',
+    clientConfigs: {
+      default: {
+        httpEndpoint: 'http://localhost:4000',
+        httpLinkOptions: {
+          credentials: 'same-origin'
+        },
+        wsEndpoint: 'ws://localhost:4000',
+        tokenName: 'apollo-token',
+        persisting: false,
+        websocketsOnly: false
+      },
+      test: {
+        httpEndpoint: 'http://localhost:5000',
+        wsEndpoint: 'ws://localhost:5000',
+        tokenName: 'apollo-token'
+      },
+      test2: '~/plugins/my-alternative-apollo-config.js'
+    }
+  }
+}
 
 // onLogin
 

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -8,6 +8,7 @@
       "esnext",
       "esnext.asynciterable",
       "dom"
-    ]
+    ],
+    "types": ["vue-cli-plugin-apollo"]
   }
 }

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -4,11 +4,14 @@
     "moduleResolution": "node",
     "strict": true,
     "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": false,
     "lib": [
       "esnext",
       "esnext.asynciterable",
       "dom"
     ],
     "types": ["vue-cli-plugin-apollo"]
-  }
+  },
+  "exclude": ["node_modules"]
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -4,13 +4,10 @@
 
 import Vue from 'vue'
 import { ApolloClient } from 'apollo-client'
+import { ApolloHelpers } from '.'
 
 declare module 'vue/types/vue' {
   interface Vue {
-    $apolloHelpers: {
-      onLogin (token: string, apolloClient?: ApolloClient<any>, tokenExpires?: number): Promise<void>
-      onLogout (apolloClient?: ApolloClient<any>): Promise<void>
-      getToken (tokenName?: string): string
-    }
+    $apolloHelpers: ApolloHelpers
   }
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -8,8 +8,8 @@ import { ApolloClient } from 'apollo-client'
 declare module 'vue/types/vue' {
   interface Vue {
     $apolloHelpers: {
-      onLogin (token: string, apolloClient?: ApolloClient<{}>, tokenExpires?: number): Promise<void>
-      onLogout (apolloClient?: ApolloClient<{}>): Promise<void>
+      onLogin (token: string, apolloClient?: ApolloClient<any>, tokenExpires?: number): Promise<void>
+      onLogout (apolloClient?: ApolloClient<any>): Promise<void>
       getToken (tokenName?: string): string
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10348,12 +10348,13 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-apollo@^3.0.0-beta.30:
-  version "3.0.0-beta.30"
-  resolved "https://registry.yarnpkg.com/vue-apollo/-/vue-apollo-3.0.0-beta.30.tgz#081bc2b8c8f9d2ffd508675c17dc1017da5ba3f4"
-  integrity sha512-uRv5JXGXCxMVyfThBtqeJVwHd7+XI/RmGjZY5kU6Ad8MGT6Da9M8T2wRmcvN4fa4fydRJuy4PheSEXS83WFUhg==
+vue-apollo@^3.0.0-rc.1:
+  version "3.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/vue-apollo/-/vue-apollo-3.0.0-rc.1.tgz#fed79fab2b77d6dfe6c5f0940ace80b0202d63e6"
+  integrity sha512-OlJMVQ9cvk75EXE2sCcFTNflAwFQsguKD7duJrC2IOEGcYQriumiNExH8FKYgmxhLF+dkykh+DLTG6YvOC+S2g==
   dependencies:
     chalk "^2.4.2"
+    serialize-javascript "^1.7.0"
     throttle-debounce "^2.1.0"
 
 vue-cli-plugin-apollo@^0.20.0:


### PR DESCRIPTION
Hello,
I have add type definition for `NuxtConfiguration`.

This add auto-completion when we write config. Example:
```ts
import NuxtConfiguration from '@nuxt/config'

const config: NuxtConfiguration = {
  apollo: {
    tokenName: 'yourApolloTokenName',
    clientConfigs: {
      default: {
        httpEndpoint: 'http://localhost:4000'
      }
  }
}
```

Thanks.