### PR TITLE
fix: serialize cookie attributes

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -12,7 +12,7 @@ export default (ctx, inject) => {
   const providerOptions = { clients: {} }
   const { app, beforeNuxtRender, req } = ctx
   const AUTH_TOKEN_NAME = '<%= options.tokenName %>'
-  const COOKIE_ATTRIBUTES = '<%= options.cookieAttributes %>'
+  const COOKIE_ATTRIBUTES = <%= serialize(options.cookieAttributes) %>
   const AUTH_TYPE = '<%= options.authenticationType %> '
 
   // Config


### PR DESCRIPTION
Forgot to serialize the cookie attributes introduced in #202 