### PR TITLE
Keep errorHandler in sync

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -89,7 +89,7 @@ export default (ctx, inject) => {
       <% } %>
       errorHandler (error) {
         <% if (options.errorHandler) { %>
-          require('<%= options.errorHandler %>').default(error, ctx)
+          return require('<%= options.errorHandler %>').default(error, ctx)
         <% } else { %>
           console.log('%cError', 'background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;', error.message)
         <% } %>


### PR DESCRIPTION
This PR allows the usage of an async errorHandler.

Currently using the `errorHandler` option may cause nuxt to send a invalid http response, since the error isn't handled in sync.

**Example**


```js
async function errorHandler() {
   // This code is executed after nuxt send its response headers
   // so its impossible to handle the error properly
}
```