### PR TITLE
add support of function-style clientConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ Add `@nuxtjs/apollo` to `modules` section of `nuxt.config.js`
         tokenName: 'apollo-token'
       },
       // alternative: user path to config which returns exact same config options
-      test2: '~/plugins/my-alternative-apollo-config.js'
+      test2: '~/plugins/my-alternative-apollo-config.js',
+      // also you can define config as a function, needed for module setup where you want to pass custom 
+      // dynamic parameters to http connection
+      custom: (context) => ({
+        httpEndpoint: 'http://localhost:4000/graphql-alt',
+        getAuth:() => 'Bearer my-dynamic-token' 
+      })
     }
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -18,8 +18,8 @@ module.exports = function (moduleOptions) {
     const clientConfig = clientConfigs[key]
 
     if (typeof clientConfig !== 'object') {
-      if (typeof clientConfig !== 'string') {
-        throw new Error(`[Apollo module] Client configuration "${key}" should be an object or a path to an exported Apollo Client config.`)
+      if (typeof clientConfig !== 'string' && typeof clientConfig !== 'function') {
+        throw new Error(`[Apollo module] Client configuration "${key}" should be an object, function or a path to an exported Apollo Client config.`)
       }
     } else if (typeof clientConfig.httpEndpoint !== 'string') {
       if (typeof clientConfig.link !== 'object') {

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -28,6 +28,8 @@ export default (ctx, inject) => {
       let <%= key %>ClientConfig
       <% if (typeof options.clientConfigs[key] === 'object') { %>
         <%= key %>ClientConfig = <%= JSON.stringify(options.clientConfigs[key], null, 2) %>
+      <% } else if (typeof options.clientConfigs[key] === 'function') { %>
+        <%= key %>ClientConfig = <%= key %>ClientConfig(ctx)
       <% } else if (typeof options.clientConfigs[key] === 'string') { %>
         <%= key %>ClientConfig = require('<%= options.clientConfigs[key] %>')
 

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -29,7 +29,7 @@ export default (ctx, inject) => {
       <% if (typeof options.clientConfigs[key] === 'object') { %>
         <%= key %>ClientConfig = <%= JSON.stringify(options.clientConfigs[key], null, 2) %>
       <% } else if (typeof options.clientConfigs[key] === 'function') { %>
-        <%= key %>ClientConfig = <%= key %>ClientConfig(ctx)
+        <%= key %>ClientConfig = <%= options.clientConfigs[key] %>(ctx)
       <% } else if (typeof options.clientConfigs[key] === 'string') { %>
         <%= key %>ClientConfig = require('<%= options.clientConfigs[key] %>')
 

--- a/test/fixture-multi-endpoints/nuxt.config.js
+++ b/test/fixture-multi-endpoints/nuxt.config.js
@@ -16,12 +16,15 @@ module.exports = {
       default: {
         httpEndpoint: process.env.HTTP_ENDPOINT,
         wsEndpoint: process.env.WS_ENDPOINT,
-        getAuth: () => 'Bearer 1234'
       },
       second: {
         httpEndpoint: process.env.HTTP_ENDPOINT,
         wsEndpoint: null
-      }
+      },
+      custom: (context) => ({
+        httpEndpoint: process.env.HTTP_ENDPOINT,
+        getAuth: () => 'Bearer 5678'
+      })
     }
   }]]
 }

--- a/test/fixture-multi-endpoints/nuxt.config.js
+++ b/test/fixture-multi-endpoints/nuxt.config.js
@@ -16,12 +16,13 @@ module.exports = {
       default: {
         httpEndpoint: process.env.HTTP_ENDPOINT,
         wsEndpoint: process.env.WS_ENDPOINT,
+        getAuth: () => 'Bearer 5678'
       },
       second: {
         httpEndpoint: process.env.HTTP_ENDPOINT,
         wsEndpoint: null
       },
-      custom: function(context) {
+      custom: function (context) {
         return {
           httpEndpoint: process.env.HTTP_ENDPOINT,
           getAuth: () => 'Bearer 5678'

--- a/test/fixture-multi-endpoints/nuxt.config.js
+++ b/test/fixture-multi-endpoints/nuxt.config.js
@@ -21,10 +21,12 @@ module.exports = {
         httpEndpoint: process.env.HTTP_ENDPOINT,
         wsEndpoint: null
       },
-      custom: (context) => ({
-        httpEndpoint: process.env.HTTP_ENDPOINT,
-        getAuth: () => 'Bearer 5678'
-      })
+      custom: function(context) {
+        return {
+          httpEndpoint: process.env.HTTP_ENDPOINT,
+          getAuth: () => 'Bearer 5678'
+        }
+      }
     }
   }]]
 }


### PR DESCRIPTION
Hello.

This is very important feature in case if you want to wrap apollo configuration in custom module and pass logic to retrieve auth token and connection URL dynamically. Otherwise it's impossible to pass dynamic parameters using closure or nuxt modules to apollo config.
