### PR TITLE
Fix: clear cache after every request in ssr

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -104,6 +104,10 @@ export default (ctx, inject) => {
     const ApolloSSR = require('vue-apollo/ssr')
     beforeNuxtRender(({ nuxtState }) => {
       nuxtState.apollo = ApolloSSR.getStates(apolloProvider)
+      // Clear apollo client cache after each request
+      // Issues: https://github.com/nuxt-community/apollo-module/issues/273
+      //         https://github.com/nuxt-community/apollo-module/issues/251
+      Object.values(apolloProvider.clients).forEach(client => client.cache.reset())
     })
   }
 


### PR DESCRIPTION
Clear apollo cache in ssr after every request. So that no extra payload is sent in next ssr request which can cause increase in response size as it'll send apollo ssr state from previous request.

Resolves:
https://github.com/nuxt-community/apollo-module/issues/273
https://github.com/nuxt-community/apollo-module/issues/251