### PR TITLE
Restore local state cache after clear on server

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -127,7 +127,7 @@ export default (ctx, inject) => {
         const onCacheInitKey = clientName === 'defaultClient' ? 'default' : clientName
         const onCacheInit = onCacheInitStore[onCacheInitKey]
         client.cache.reset()
-        onCacheInit(client.cache)
+        if (typeof onCacheInit === 'function') onCacheInit(client.cache)
       })
     })
   }

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -14,6 +14,7 @@ export default (ctx, inject) => {
   const COOKIE_ATTRIBUTES = <%= serialize(options.cookieAttributes) %>
   const AUTH_TYPE = '<%= options.authenticationType %> '
   const cookies = new Cookie(req && req.headers.cookie)
+  const onCacheInitStore = { }
 
   // Config
   <% Object.keys(options.clientConfigs).forEach((key) => { %>
@@ -36,6 +37,11 @@ export default (ctx, inject) => {
 
         <%= key %>ClientConfig = <%= key %>ClientConfig(ctx)
       <% } %>
+
+      if (process.server) {
+        onCacheInitStore['<%= key %>'] = <%= key %>ClientConfig.onCacheInit
+        <%= key %>ClientConfig.onCacheInit = null
+      }
 
       const <%= key %>ValidateToken = () => true
 
@@ -62,7 +68,7 @@ export default (ctx, inject) => {
       <%= key %>ClientConfig.ssr = !!process.server
       <%= key %>ClientConfig.cache = <%= key %>Cache
       <%= key %>ClientConfig.tokenName = <%= key %>TokenName
-      
+
       // if ssr we'd still like to have our webclient's cookies
       if (process.server && req && req.headers && req.headers.cookie) {
         if (!<%= key %>ClientConfig.httpLinkOptions) {
@@ -116,7 +122,13 @@ export default (ctx, inject) => {
       // Clear apollo client cache after each request
       // Issues: https://github.com/nuxt-community/apollo-module/issues/273
       //         https://github.com/nuxt-community/apollo-module/issues/251
-      Object.values(apolloProvider.clients).forEach(client => client.cache.reset())
+      Object.keys(apolloProvider.clients).forEach(clientName => {
+        const client = apolloProvider.clients[clientName]
+        const onCacheInitKey = clientName === 'defaultClient' ? 'default' : clientName
+        const onCacheInit = onCacheInitStore[onCacheInitKey]
+        client.cache.reset()
+        onCacheInit(client.cache)
+      })
     })
   }
 


### PR DESCRIPTION
A recent fix (#274) made it so the apollo client cache is cleared after each request.  This had the unintended side effect of clearing all local state values set using `onCacheInit` as pointed out in #286.  As a result, the apollo client cache on the server is always empty, making server side population of local state impossible.

This fix runs `onCacheInit` on the server after the cache is cleared.  It should allow local state usage on the server while adhering to the goals of #274.