### PR TITLE
fix(types): export client config interface

### DIFF
--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -7,7 +7,7 @@ import { ApolloClientClientConfig } from 'vue-cli-plugin-apollo/graphql-client'
 import Vue, { ComponentOptions } from 'vue'
 import { ApolloHelpers, CookieAttributes } from '.'
 
-interface ApolloClientConfig extends ApolloClientClientConfig<any> {
+export interface ApolloClientConfig extends ApolloClientClientConfig<any> {
   httpEndpoint: string
   websocketsOnly?: boolean
 }


### PR DESCRIPTION
Please allow access to client config interface by exporting it.
Useful for implementing an ApolloClientConfig in a separate file.