### PR TITLE
Allow wsEndpoint only config

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -21,7 +21,7 @@ module.exports = function (moduleOptions) {
       if (typeof clientConfig !== 'string') {
         throw new Error(`[Apollo module] Client configuration "${key}" should be an object or a path to an exported Apollo Client config.`)
       }
-    } else if (typeof clientConfig.httpEndpoint !== 'string') {
+    } else if (typeof clientConfig.httpEndpoint !== 'string' && typeof clientConfig.wsEndpoint !== 'string') {
       if (typeof clientConfig.link !== 'object') {
         throw new Error(`[Apollo module] Client configuration "${key}" must define httpEndpoint or link option.`)
       }


### PR DESCRIPTION
Error:
```
Client configuration "default" must define httpEndpoint or link option
```

with config:
```
  apollo: {
    clientConfigs: {
      default: {
        wsEndpoint: 'ws://localhost/raphql',
        websocketsOnly: true
      }
    }
  },
```