### PR TITLE
fix TypeError Cannot read property 'defaultClient' of undefined

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -54,7 +54,7 @@ export default (ctx, inject) => {
         : new InMemoryCache(<%= key %>ClientConfig.inMemoryCacheOptions ? <%= key %>ClientConfig.inMemoryCacheOptions: undefined)
 
       if (!process.server) {
-        <%= key %>Cache.restore(window.__NUXT__ ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
+        <%= key %>Cache.restore(window.__NUXT__ && window.__NUXT__.apollo ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
       }
 
       if (!<%= key %>ClientConfig.getAuth) {


### PR DESCRIPTION
This PR can avoid `TypeError: Cannot read property 'defaultClient' of undefined` issue under some circumstances.

I personally encountered this error when using `nuxt generate` to deploy my site to Github Pages. After I use `@nuxtjs/apollo`, some of the pages with redirect middleware cannot be opened, with error like below:

<img width="378" alt="Screen Shot 2020-05-07 at 4 30 00 午後" src="https://user-images.githubusercontent.com/11518941/81275323-1627a080-9084-11ea-9c12-3b8c8fe732b4.png">

<img width="557" alt="Screen Shot 2020-05-07 at 4 30 13 午後" src="https://user-images.githubusercontent.com/11518941/81275398-38212300-9084-11ea-8bab-3984fa65eccc.png">

This PR should fix this issue.
