### PR TITLE
fix(plugin): check if __NUXT__.apollo exists

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -54,7 +54,7 @@ export default (ctx, inject) => {
         : new InMemoryCache(<%= key %>ClientConfig.inMemoryCacheOptions ? <%= key %>ClientConfig.inMemoryCacheOptions: undefined)
 
       if (!process.server) {
-        <%= key %>Cache.restore(window.__NUXT__ ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
+        <%= key %>Cache.restore(window.__NUXT__ && window.__NUXT__.apollo ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
       }
 
       if (!<%= key %>ClientConfig.getAuth) {


### PR DESCRIPTION
Hi there!

With the full static mode coming (you can test with `nuxt-edge`), the module fails on the SPA fallback since `window.__NUXT__` now exists but `apollo` is not set.

This PR add a check to see if `window.__NUXT__.apollo` is defined.

![Screenshot 2020-05-13 at 19 30 39](https://user-images.githubusercontent.com/904724/81845010-3f4aa400-9550-11ea-86da-55387c69403a.png)
