### PR TITLE
fix: break reference to state object

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -118,7 +118,13 @@ export default (ctx, inject) => {
   if (process.server) {
     const ApolloSSR = require('vue-apollo/ssr')
     beforeNuxtRender(({ nuxtState }) => {
-      nuxtState.apollo = ApolloSSR.getStates(apolloProvider)
+      nuxtState.apollo = {}
+      const states = ApolloSSR.getStates(apolloProvider)
+
+      for (let clientName in states) {
+        nuxtState.apollo[clientName] = Object.assign({}, states[clientName])
+      }
+
       // Clear apollo client cache after each request
       // Issues: https://github.com/nuxt-community/apollo-module/issues/273
       //         https://github.com/nuxt-community/apollo-module/issues/251


### PR DESCRIPTION
I found and issue with rehydrating the InMemoryCache.

Since the state is retrieved as a reference here: https://github.com/nuxt-community/apollo-module/blob/master/lib/templates/plugin.js#L121

it is cleared with a call to `reset` there: https://github.com/nuxt-community/apollo-module/blob/master/lib/templates/plugin.js#L129

Thus also clearing the previously stored states on the `nuxtState` object.

I broke the reference by iterating the states and calling `Object.assign` on each of them, while assigning it back to the `nuxtState.apollo` object.