### PR TITLE
Nuxtjs 2.14.0 compatibility

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -101,7 +101,7 @@ module.exports = function (moduleOptions) {
       } else {
         config.externals = [
           nodeExternals({
-            whitelist: [apolloModuleRe]
+            allowlist: [apolloModuleRe]
           })
         ]
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "universal-cookie": "^4.0.3",
     "vue-apollo": "^3.0.3",
     "vue-cli-plugin-apollo": "^0.21.3",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-node-externals": "2.5.0"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.6.5"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "cross-fetch": "^3.0.4",
     "universal-cookie": "^4.0.3",
-    "vue-apollo": "^3.0.3",
+    "vue-apollo": "3.0.4",
     "vue-cli-plugin-apollo": "^0.21.3",
     "webpack-node-externals": "2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "dependencies": {
     "cross-fetch": "^3.0.4",
     "universal-cookie": "^4.0.3",
-    "vue-apollo": "3.0.4",
+    "vue-apollo": "^3.0.4",
     "vue-cli-plugin-apollo": "^0.21.3",
-    "webpack-node-externals": "2.5.0"
+    "webpack-node-externals": "^2.5.0"
   },
   "peerDependencies": {
     "apollo-cache-inmemory": "^1.6.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12244,6 +12244,11 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-node-externals@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-2.5.0.tgz#8d50f3289c71bc2b921a8da228e0b652acc503f1"
+  integrity sha512-g7/Z7Q/gsP8GkJkKZuJggn6RSb5PvxW1YD5vvmRZIxaSxAzkqjfL5n9CslVmNYlSqBVCyiqFgOqVS2IOObCSRg==
+
 webpack-node-externals@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9979,7 +9979,7 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -10600,6 +10600,13 @@ serialize-javascript@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
   integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
+
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-placeholder@^1.2.1:
   version "1.2.1"
@@ -12010,13 +12017,13 @@ vscode-uri@^1.0.6:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
   integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
-vue-apollo@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/vue-apollo/-/vue-apollo-3.0.3.tgz#7f29558df76eec0f03251847eef153816a261827"
-  integrity sha512-WJaQ1v/i46/oIPlKv7J0Tx6tTlbuaeCdhrAbL06h+Zca2gzr5ywjUFpl8ijMTGJsQ+Ph/U4xEpBFBOMxQmL+7g==
+vue-apollo@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/vue-apollo/-/vue-apollo-3.0.4.tgz#d48a990d02c1febb5248d097f921c74c50a22e8a"
+  integrity sha512-sthSS9E6FB7OMmSJmIG7e89QZvzwK/1PCD8A/IfGBST48pxY7sdSxRp22Gu2/s/gxQBnQPI1H1ZPZE97IG+zXA==
   dependencies:
     chalk "^2.4.2"
-    serialize-javascript "^2.1.0"
+    serialize-javascript "^4.0.0"
     throttle-debounce "^2.1.0"
 
 vue-cli-plugin-apollo@^0.21.3:


### PR DESCRIPTION
* updated `webpack-node-externals` from `^1.7.2` to `2.5.0` *(See https://github.com/nuxt/nuxt.js/compare/v2.13.3...v2.14.0)*
* updated `nodeExternals` to match new parameters 
* updated `vue-apollo` from `^3.0.3` to `3.0.4` which introduce breaking change with typescript (types declaration for `*.gql` and `*.graphql` was removed)
* updated `README.md` 

~note: removing `^` before versions in `package.json` is intentional~