### PR TITLE
refactor: add types for helpers and provider into nuxt context

### DIFF
--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -3,6 +3,7 @@
  */
 
 import { VueApolloComponentOptions } from 'vue-apollo/types/options'
+import { ApolloProvider } from 'vue-apollo/types/apollo-provider'
 import { ApolloClientClientConfig } from 'vue-cli-plugin-apollo/graphql-client'
 import Vue, { ComponentOptions } from 'vue'
 import { ApolloHelpers, CookieAttributes } from '.'
@@ -14,7 +15,7 @@ export interface ApolloClientConfig extends ApolloClientClientConfig<any> {
 
 interface NuxtApolloConfiguration {
   tokenName?: string
-  cookieAttributes? : CookieAttributes
+  cookieAttributes?: CookieAttributes
   tokenExpires?: number
   includeNodeModules?: boolean
   authenticationType?: string
@@ -45,6 +46,10 @@ declare module '@nuxt/types' {
     apollo?: NuxtApolloConfiguration
   }
   interface NuxtAppOptions extends ComponentOptions<Vue> {
+    $apolloHelpers: ApolloHelpers
+    apolloProvider: ApolloProvider
+  }
+  interface Context {
     $apolloHelpers: ApolloHelpers
   }
 }


### PR DESCRIPTION
Hey guys,


I have add type definition for nuxt Context and ApolloProvider into NuxtAppOptions.

This will allow us to access `$apolloHelpers` from the context and apolloProvider from `context.app`

Example: 

```javascript
import { Plugin, Context } from '@nuxt/types'

const createRepo = ($apolloHelpers, $apollo) => { 
  console.log('create my repository somehow') 
}

const Repositories: Plugin = (
  { $apolloHelpers, app: { apolloProvider } }: Context,
  inject
) => {
  inject(
    'repositories',
    createRepo($apolloHelpers, apolloProvider.defaultClient)
  )
}

export default Repositories
``` 

Thanks.