### PR TITLE
Improve advanced configuration example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Checkout [Official example](https://github.com/nuxt/nuxt.js/tree/dev/examples/vu
     // Sets up the apollo client endpoints
     clientConfigs: {
       // recommended: use a file to declare the client configuration (see below for example)
-      default: '~/plugins/my-alternative-apollo-config.js'
+      default: '~/plugins/my-alternative-apollo-config.js',
 
       // you can setup multiple clients
       alternativeClient: {

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Checkout [Official example](https://github.com/nuxt/nuxt.js/tree/dev/examples/vu
       // recommended: use a file to declare the client configuration (see below for example)
       default: '~/plugins/my-alternative-apollo-config.js',
 
-      // you can setup multiple clients
+      // you can setup multiple clients with arbitrary names
       alternativeClient: {
         // required
         httpEndpoint: 'http://localhost:4000',


### PR DESCRIPTION
I fixed the syntax of the example configuration given in the "Advanced Configuration" section in the `README.md`. Also I added a comment that clarifies that the name of the non-default clients in `clientConfigs` is arbitrary.

Maybe there should also be an example that shows how to access the non-default clients. When I started using apollo-module I had to find out by trial-and-error. Tell me, if I should add it to this PR.

Cheers :v: