### PR TITLE
WIP: fix: set apollo-token cookie in SSR

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -2,18 +2,16 @@ import Vue from 'vue'
 import VueApollo from 'vue-apollo'
 import 'cross-fetch/polyfill'
 import { createApolloClient, restartWebsockets } from 'vue-cli-plugin-apollo/graphql-client'
-import Cookie from 'universal-cookie'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 
 Vue.use(VueApollo)
 
 export default (ctx, inject) => {
   const providerOptions = { clients: {} }
-  const { app, beforeNuxtRender, req } = ctx
+  const { app, beforeNuxtRender, req, $cookies } = ctx
   const AUTH_TOKEN_NAME = '<%= options.tokenName %>'
   const COOKIE_ATTRIBUTES = <%= serialize(options.cookieAttributes) %>
   const AUTH_TYPE = '<%= options.authenticationType %> '
-  const cookies = new Cookie(req && req.headers.cookie)
   const onCacheInitStore = { }
 
   // Config
@@ -21,7 +19,7 @@ export default (ctx, inject) => {
       const <%= key %>TokenName = '<%= options.clientConfigs[key].tokenName %>'  || AUTH_TOKEN_NAME
 
       function <%= key %>GetAuth () {
-        const token = cookies.get(<%= key %>TokenName)
+        const token = $cookies.get(<%= key %>TokenName, { parseJSON: false })
         return token && <%= key %>ClientConfig.validateToken(token) ? AUTH_TYPE + token : ''
       }
 
@@ -148,9 +146,9 @@ export default (ctx, inject) => {
       }
 
       if (token) {
-        cookies.set(AUTH_TOKEN_NAME, token, cookieAttributes)
+        $cookies.set(AUTH_TOKEN_NAME, token, cookieAttributes)
       } else {
-        cookies.remove(AUTH_TOKEN_NAME, cookieAttributes)
+        $cookies.remove(AUTH_TOKEN_NAME, cookieAttributes)
       }
       if (apolloClient.wsClient) restartWebsockets(apolloClient.wsClient)
       if (!skipResetStore) {
@@ -163,7 +161,7 @@ export default (ctx, inject) => {
       }
     },
     onLogout: async (apolloClient = apolloProvider.defaultClient, skipResetStore = false) => {
-      cookies.remove(AUTH_TOKEN_NAME, COOKIE_ATTRIBUTES)
+      $cookies.remove(AUTH_TOKEN_NAME, COOKIE_ATTRIBUTES)
       if (apolloClient.wsClient) restartWebsockets(apolloClient.wsClient)
       if (!skipResetStore) {
         try {
@@ -175,7 +173,7 @@ export default (ctx, inject) => {
       }
     },
     getToken: (tokenName = AUTH_TOKEN_NAME) => {
-      return cookies.get(tokenName)
+      return $cookies.get(tokenName, { parseJSON: false })
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -36,20 +36,19 @@
   },
   "dependencies": {
     "cross-fetch": "^3.0.4",
-    "universal-cookie": "^4.0.3",
     "vue-apollo": "^3.0.4",
     "vue-cli-plugin-apollo": "^0.21.3",
     "webpack-node-externals": "^2.5.0"
   },
   "peerDependencies": {
-    "apollo-cache-inmemory": "^1.6.5"
+    "apollo-cache-inmemory": "^1.6.5",
+    "cookie-universal-nuxt": "^2.1.4"
   },
   "devDependencies": {
     "@babel/core": "latest",
     "@babel/preset-env": "latest",
     "@nuxt/types": "latest",
     "@types/graphql": "latest",
-    "@types/universal-cookie": "latest",
     "codecov": "latest",
     "core-js": "^2.6.11",
     "dotenv": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,11 +1460,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
-  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
-
 "@types/cookies@*":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.4.tgz#26dedf791701abc0e36b5b79a5722f40e455f87b"
@@ -1627,11 +1622,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.22.tgz#34bcdf6b6cb5fc0db33d24816ad9d3ece22feea4"
   integrity sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==
 
-"@types/object-assign@^4.0.30":
-  version "4.0.30"
-  resolved "https://registry.yarnpkg.com/@types/object-assign/-/object-assign-4.0.30.tgz#8949371d5a99f4381ee0f1df0a9b7a187e07e652"
-  integrity sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=
-
 "@types/optimize-css-assets-webpack-plugin@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz#1f437ef9ef937b393687a8819be2d2fddc03b069"
@@ -1691,11 +1681,6 @@
   integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
   dependencies:
     source-map "^0.6.1"
-
-"@types/universal-cookie@latest":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/universal-cookie/-/universal-cookie-2.2.0.tgz#36fba91f8a8c64cfd109520d15ec2ec3f32561e9"
-  integrity sha512-fNgC782wfxAZZLDfFM70AgDzYh/VX7tH8NPl/fYNgoseXVLTg+vQf2zhzbWDlJiO0fKXwCL54HOKtXpjcV5C+A==
 
 "@types/webpack-bundle-analyzer@^2.13.3":
   version "2.13.3"
@@ -4068,7 +4053,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.0, cookie@^0.4.0:
+cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
@@ -11785,16 +11770,6 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
-universal-cookie@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.3.tgz#c2fa59127260e6ad21ef3e0cdd66ad453cbc41f6"
-  integrity sha512-YbEHRs7bYOBTIWedTR9koVEe2mXrq+xdjTJZcoKJK/pQaE6ni28ak2AKXFpevb+X6w3iU5SXzWDiJkmpDRb9qw==
-  dependencies:
-    "@types/cookie" "^0.3.3"
-    "@types/object-assign" "^4.0.30"
-    cookie "^0.4.0"
-    object-assign "^4.1.1"
-
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -12017,7 +11992,7 @@ vscode-uri@^1.0.6:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
   integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
-vue-apollo@3.0.4:
+vue-apollo@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/vue-apollo/-/vue-apollo-3.0.4.tgz#d48a990d02c1febb5248d097f921c74c50a22e8a"
   integrity sha512-sthSS9E6FB7OMmSJmIG7e89QZvzwK/1PCD8A/IfGBST48pxY7sdSxRp22Gu2/s/gxQBnQPI1H1ZPZE97IG+zXA==
@@ -12251,15 +12226,15 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-node-externals@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-2.5.0.tgz#8d50f3289c71bc2b921a8da228e0b652acc503f1"
-  integrity sha512-g7/Z7Q/gsP8GkJkKZuJggn6RSb5PvxW1YD5vvmRZIxaSxAzkqjfL5n9CslVmNYlSqBVCyiqFgOqVS2IOObCSRg==
-
 webpack-node-externals@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
   integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
+
+webpack-node-externals@^2.5.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-2.5.2.tgz#178e017a24fec6015bc9e672c77958a6afac861d"
+  integrity sha512-aHdl/y2N7PW2Sx7K+r3AxpJO+aDMcYzMQd60Qxefq3+EwhewSbTBqNumOsCE1JsCUNoyfGj5465N0sSf6hc/5w==
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"


### PR DESCRIPTION
This fixes #312. 

This PR's description and its content are WIP. We need to figure out whether we want the implicit dependency on `cookie-universal-nuxt` or if there's a different solution.

Prior to this, the used cookie library only supports setting cookies in SSR, if it is explicitly called in a middleware. So instead of doing this manually, usage of cookie-universal-nuxt is introduced. It is assumed to be present in the nuxt context.