### PR TITLE
Set defaultOptions for each apollo client

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -65,6 +65,10 @@ export default (ctx, inject) => {
         <%= key %>ClientConfig.httpEndpoint = <%= key %>ClientConfig.browserHttpEndpoint
       }
 
+      <% if (options.defaultOptions) { %>
+        <%= key %>ClientConfig.apollo = { defaultOptions: <%= JSON.stringify(options.defaultOptions) %> }
+      <% } %>
+
       <%= key %>ClientConfig.ssr = !!process.server
       <%= key %>ClientConfig.cache = <%= key %>Cache
       <%= key %>ClientConfig.tokenName = <%= key %>TokenName


### PR DESCRIPTION
The PR #214 claimed that you can set defaultOptions in `nuxt.config.js`, but I couldn't get it to work and it seems like people are facing the same problem like me (see Issue #334)

**The problem:**

I got suspicious and tried to look into the options of the apollo client I was using. In my code I added this lines to print the client's defaultOptions:
``` js
const client = this.app.apolloProvider.defaultClient;
console.log(client.defaultOptions);
```

Which yielded the following result: `{}` 

As you can see the defaultOptions are empty, eventhough they are set in `nuxt.config.js`.

Excerpt of my `nuxt.config.js` file for context:

``` js
// ...
apollo: {
  // ...
  defaultOptions: {
    query: {
      fetchPolicy: 'no-cache',
      errorPolicy: 'all'
    }
  }
},
// ...
```

**The solution:**

I added the defaultOptions object that is read from `nuxt.config.js` to `apollo` Object of each client. This is somewhat similar to the solution that was proposed here: https://github.com/nuxt-community/apollo-module/issues/161#issuecomment-545094100

When I now look into the client's defaultOptions, I can see options I configured in `nuxt.config.js`:

``` js
{
  query: {​​
    errorPolicy: "all"
    fetchPolicy: "no-cache"
​​  }
}
```

Cheers :v:



