### PR TITLE
fix: server side renderings

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -14,7 +14,6 @@ export default (ctx, inject) => {
   const COOKIE_ATTRIBUTES = <%= serialize(options.cookieAttributes) %>
   const AUTH_TYPE = '<%= options.authenticationType %> '
   const cookies = new Cookie(req && req.headers.cookie)
-  const onCacheInitStore = { }
 
   // Config
   <% Object.keys(options.clientConfigs).forEach((key) => { %>
@@ -38,10 +37,6 @@ export default (ctx, inject) => {
         <%= key %>ClientConfig = <%= key %>ClientConfig(ctx)
       <% } %>
 
-      if (process.server) {
-        onCacheInitStore['<%= key %>'] = <%= key %>ClientConfig.onCacheInit
-        <%= key %>ClientConfig.onCacheInit = null
-      }
 
       const <%= key %>ValidateToken = () => true
 
@@ -118,23 +113,7 @@ export default (ctx, inject) => {
   if (process.server) {
     const ApolloSSR = require('vue-apollo/ssr')
     beforeNuxtRender(({ nuxtState }) => {
-      nuxtState.apollo = {}
-      const states = ApolloSSR.getStates(apolloProvider)
-
-      for (let clientName in states) {
-        nuxtState.apollo[clientName] = Object.assign({}, states[clientName])
-      }
-
-      // Clear apollo client cache after each request
-      // Issues: https://github.com/nuxt-community/apollo-module/issues/273
-      //         https://github.com/nuxt-community/apollo-module/issues/251
-      Object.keys(apolloProvider.clients).forEach(clientName => {
-        const client = apolloProvider.clients[clientName]
-        const onCacheInitKey = clientName === 'defaultClient' ? 'default' : clientName
-        const onCacheInit = onCacheInitStore[onCacheInitKey]
-        client.cache.reset()
-        if (typeof onCacheInit === 'function') onCacheInit(client.cache)
-      })
+      nuxtState.apollo = ApolloSSR.getStates(apolloProvider)
     })
   }
 


### PR DESCRIPTION
Fixing: Issue: #352

In https://github.com/nuxt-community/apollo-module/pull/336 the server side rendering was broken.
The problem is that when assigning the apollo cache to the nuxt state, in `beforeNuxtRender` the state is actually still empty.
It only works because a reference is assigned there, which is later populated.

In https://github.com/nuxt-community/apollo-module/pull/274  another problem was fixed: Before this fix everything which was populated in the cache before `beforeNuxtRender` was cleared.

To fix both issues I propose to remove the workaround introduced in https://github.com/nuxt-community/apollo-module/pull/274 for the case when the `cache` object is shared across requests.
Since the server is handling requests in parallel, its simply impossible to have a shared cache instance.
Users of `nuxtjs/apollo` need to make sure that the cache instance is not shared, there is no other way.

That's why I propose to delete this workaround code, to fix all issues at the same time.

