### PR TITLE
Extend NuxtConfig with apollo property

### DIFF
--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -52,7 +52,7 @@ declare module '@nuxt/types' {
   interface Context {
     $apolloHelpers: ApolloHelpers
   }
-  // Nuxt 2.14.12+
+  // Nuxt 2.13.1+
   interface NuxtConfig {
     apollo?: NuxtApolloConfiguration
   }

--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -52,4 +52,8 @@ declare module '@nuxt/types' {
   interface Context {
     $apolloHelpers: ApolloHelpers
   }
+  // Nuxt 2.14.12+
+  interface NuxtConfig {
+    apollo?: NuxtApolloConfiguration
+  }
 }


### PR DESCRIPTION
As `Configuration` is deprecated in [v2.13.1](https://github.com/nuxt/nuxt.js/blob/56b158e7d689ba9f57e7aa83d672f5f32b18767b/packages/types/config/index.d.ts#L25-L28) of Nuxt, I believe.