### PR TITLE
docs(README.md): update contributing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,6 @@ mutation authenticateUser($email:String!,$password:String!){
 
 If your gql backend is prepared start running nuxt as follow
 ```bash
-npm install
-npm run dev
+yarn install
+yarn dev
 ```


### PR DESCRIPTION
The project uses yarn for package management
(and also has a `yarn.lock` file but not `package-lock.json` file). However the contributing
mention using `npm` for it. The command 
`npm install` fails after a fresh clone due to dependency resolution failure.