### PR TITLE
fix: per-client `tokenName` from config files

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -17,13 +17,6 @@ export default (ctx, inject) => {
 
   // Config
   <% Object.keys(options.clientConfigs).forEach((key) => { %>
-      const <%= key %>TokenName = '<%= options.clientConfigs[key].tokenName %>'  || AUTH_TOKEN_NAME
-
-      function <%= key %>GetAuth () {
-        const token = cookies.get(<%= key %>TokenName)
-        return token && <%= key %>ClientConfig.validateToken(token) ? AUTH_TYPE + token : ''
-      }
-
       let <%= key %>ClientConfig
       <% if (typeof options.clientConfigs[key] === 'object') { %>
         <%= key %>ClientConfig = <%= JSON.stringify(options.clientConfigs[key], null, 2) %>
@@ -37,7 +30,13 @@ export default (ctx, inject) => {
         <%= key %>ClientConfig = <%= key %>ClientConfig(ctx)
       <% } %>
 
+      const <%= key %>TokenName = <%= key %>ClientConfig.tokenName || AUTH_TOKEN_NAME
 
+      function <%= key %>GetAuth () {
+        const token = cookies.get(<%= key %>TokenName)
+        return token && <%= key %>ClientConfig.validateToken(token) ? AUTH_TYPE + token : ''
+      }
+        
       const <%= key %>ValidateToken = () => true
 
       if (!<%= key %>ClientConfig.validateToken) {


### PR DESCRIPTION
Fixes #386

When defining multiple apollo clients in external files, the `tokenName` for each client would not be set correctly in the compiled plugin.

This PR changes the template so that the `tokenName` is read _after_ reading the config file instead of before.