### PR TITLE
fix(test): fix the errors that are failing CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,5 +32,5 @@ jobs:
           name: Tests
           command: yarn test
           environment:
-            HTTP_ENDPOINT: https://api.graph.cool/simple/v1/cjvqu5trs23l90138hm4t8uof
+            HTTP_ENDPOINT: https://rickandmortyapi.com/graphql
             WS_ENDPOINT: wss://subscriptions.us-west-2.graph.cool/v1/cjvqu5trs23l90138hm4t8uof

--- a/test/fixture-local-state/plugins/apollo-config.js
+++ b/test/fixture-local-state/plugins/apollo-config.js
@@ -17,7 +17,7 @@ export default function (ctx) {
         }
       }
     },
-    onCacheInit: cache => {
+    onCacheInit: (cache) => {
       const data = {
         connected: false
       }

--- a/test/fixture/pages/asyncData.vue
+++ b/test/fixture/pages/asyncData.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div v-for="post in allPosts" :key="post.id">{{ post.id }}</div>
+        <div v-for="episode in episodesByIds" :key="episode.name">{{ episode.name }}</div>
     </div>
 </template>
 
@@ -15,19 +15,19 @@ export default {
     },
     data () {
         return {
-            allPosts: []
+          episodesByIds: []
         }
     },
     async asyncData({ app }) {
         const client = app.apolloProvider.defaultClient
-        const allPosts = await client.query({
+        const episodesByIds = await client.query({
             query: gql`{
-                allPosts {
-                    id
+                episodesByIds(ids: [1]) {
+                    name
                 }
             }`
-        }).then(({ data }) => data && data.allPosts)
-        return { allPosts }
+        }).then(({ data }) => data && data.episodesByIds)
+        return { episodesByIds }
     }
 }
 </script>

--- a/test/fixture/pages/mounted.vue
+++ b/test/fixture/pages/mounted.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div v-for="post in allPosts" :key="post.id">{{ post.id }}</div>
+        <div v-for="episode in episodesByIds" :key="episode.name">{{ episode.name }}</div>
     </div>
 </template>
 
@@ -15,17 +15,17 @@ export default {
     },
     data () {
         return {
-            allPosts: []
+            episodesByIds: []
         }
     },
     async mounted() {
-        this.allPosts = await this.$apollo.query({
+        this.episodesByIds = await this.$apollo.query({
             query: gql`{
-                allPosts {
-                    id
+                episodesByIds(ids: [1]) {
+                    name
                 }
             }`
-        }).then(({ data }) => data && data.allPosts)
+        }).then(({ data }) => data && data.episodesByIds)
     }
 }
 </script>

--- a/test/fixture/pages/normalQuery.vue
+++ b/test/fixture/pages/normalQuery.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div v-for="post in allPosts" :key="post.id">{{ post.id }}</div>
+        <div v-for="episode in episodesByIds" :key="episode.name">{{ episode.name }}</div>
     </div>
 </template>
 
@@ -15,14 +15,14 @@ export default {
     },
     data () {
         return {
-            allPosts: []
+          episodesByIds: []
         }
     },
     apollo: {
-        allPosts: {
+        episodesByIds: {
             query: gql`{
-                allPosts {
-                    id
+                episodesByIds(ids: [1]) {
+                    name
                 }
             }`
         }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -26,12 +26,12 @@ describe('basic', () => {
 
   test('normalQuery', async () => {
     const html = await get('/normalQuery')
-    expect(html).toContain('cjw1jhoxi1f4g0112ayaq3pyz')
+    expect(html).toContain('Pilot')
   })
 
   test('asyncData', async () => {
     const html = await get('/asyncData')
-    expect(html).toContain('cjw1jhoxi1f4g0112ayaq3pyz')
+    expect(html).toContain('Pilot')
   })
 
   test('mounted & smart query', async () => {


### PR DESCRIPTION
The CircleCI tests are failing in at least 3 places:`yarn lint`, `yarn test` and `tsc`.

## Linting

CircleCI build is failing from a tiny linter error. This fixes it

```bash
$ yarn lint

/home/circleci/project/test/fixture-local-state/plugins/apollo-config.js
  20:18  error  Expected parentheses around arrow function argument having a body with curly braces  arrow-parens
```

## Jest

With the linter error fixed, the next step `yarn test` is now running and showing errors.  
It looks like the reason for these errors is that the API the tests are hitting is down.

I'm not sure if this API will come back or not. For the meantime, I've adapted the code to use a different graphql endpoint.

We may want to look at creating a mock graphql endpoint to remove the flake from the tests

## tsc

NOTE: Looking in to this now