### PR TITLE
fix(nuxt-bridge): add support for nuxt bridge

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -113,6 +113,7 @@ export default (ctx, inject) => {
   const apolloProvider = new VueApollo(vueApolloOptions)
   // Allow access to the provider in the context
   app.apolloProvider = apolloProvider
+  inject('theApolloProvider', apolloProvider);
 
   if (process.server) {
     const ApolloSSR = require('vue-apollo/ssr')


### PR DESCRIPTION
# Providing an Apollo Client

Nuxt Bridge exposes the Nuxt 2 context via nuxtApp.nuxt2Context.
However, when assining the apolloProvider to `app.apolloProvider`, the apolloProvider is not added to this context. (https://github.com/nuxt-community/apollo-module/blob/master/lib/templates/plugin.js#L115)

In order to get the apolloProvider onto this nuxt2Context, we must use inject().
However, it requires a different name than "apolloProvider" when injecting, or we get errors.

With these changes, it's now possible to provide the apollo client as before:

```vue
// layouts/default.vue
<script setup>
import { provideApolloClient } from '@vue/apollo-composable';

provideApolloClient(useNuxtApp().nuxt2Context.$theApolloProvider?.defaultClient);
</script>
```

Once the replacement for `onGlobalSetup()` is added, we can move this code back to a plugin: https://github.com/nuxt/framework/pull/2408

Note: This is a short term solution for Nuxt Bridge, and will need revisiting Nuxt 3.