### PR TITLE
docs: add reference to server packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 ---
 
+> For defining a GraphQL server in Nuxt 3, you may want to have a look at the [Apollo Server integration package for Nuxt](https://github.com/apollo-server-integrations/apollo-server-integration-h3) and the [GraphQL server toolkit Nuxt module](https://github.com/tobiasdiez/nuxt-graphql-server).
+
 ## Preview
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/edit/nuxt-apollo-demo)


### PR DESCRIPTION
Add a (shameless) reference to two packages that I developed to make the dev experience for developing GraphQL servers with Nuxt more pleasant. 

I think it makes sense to have a cross-reference since people using the Apollo module might also be interested in defining their own Apollo server with Nuxt.