### PR TITLE
fix useMutation example

### DIFF
--- a/docs/content/1.getting-started/3.composables.md
+++ b/docs/content/1.getting-started/3.composables.md
@@ -92,7 +92,7 @@ const variables = {
   email: 'jd@example.com'
 }
 
-const { mutate } = useMutation(query, variables)
+const { mutate } = useMutation(query, { variables })
 ```
 
 > More Information on [Vue Apollo's `useMutation`](https://v4.apollo.vuejs.org/api/use-mutation.html#usemutation)


### PR DESCRIPTION
`variables` is a property of the `options` object, see [here](https://v4.apollo.vuejs.org/api/use-mutation.html#parameters).

Is there a reason why `vue-apollo` doesn't give `variables` its own parameter in `useMutation` while it does for `useQuery`/`useSubscription`?