### PR TITLE
Resolve location of `@vue/apollo-composable` using node module resolution algo

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'module'
 import { existsSync } from 'fs'
 import jiti from 'jiti'
 import { Ref } from 'vue'
@@ -9,6 +10,7 @@ import type { ClientConfig, NuxtApolloConfig, ErrorResponse } from './types'
 
 export type { ClientConfig, ErrorResponse }
 
+const require = createRequire(import.meta.url)
 const logger = useLogger(name)
 
 async function readConfigFile (path: string): Promise<ClientConfig> {
@@ -141,7 +143,7 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
             'useGlobalQueryLoading',
             'useGlobalMutationLoading',
             'useGlobalSubscriptionLoading'
-          ].map(n => ({ name: n, from: '@vue/apollo-composable' })))
+          ].map((n) => ({ name: n, from: resolve(require.resolve("@vue/apollo-composable")) }))
     ])
 
     nuxt.hook('vite:extendConfig', (config) => {


### PR DESCRIPTION
Fixes #519

See https://github.com/nuxt-modules/apollo/issues/519#issuecomment-1616157758 for analysis of the problem and suggested solution (which this PR implements)

Tested this solution using patch-package and the module (`@vue/apollo-composable`s main module) resolves correctly when it's at either location (`./node_modules/@vue/apollo-composable` or `./node_modules/@nuxtjs/apollo/node_modules/@vue/apollo-composable`)