### PR TITLE
fix: provide Nuxt app context for useCookie call after async

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -4,6 +4,7 @@ import type { OperationVariables, QueryOptions } from '@apollo/client'
 import type { AsyncData } from 'nuxt/dist/app/composables'
 import type { NuxtAppApollo } from '../types'
 import { ref, useCookie, useNuxtApp, useAsyncData } from '#imports'
+import { callWithNuxt } from '#app'
 import NuxtApollo from '#build/apollo'
 
 type TQuery<T> = QueryOptions<OperationVariables, T>['query']
@@ -68,7 +69,9 @@ export const useApollo = () => {
 
     const tokenName = conf.tokenName!
 
-    return conf?.tokenStorage === 'cookie' ? useCookie(tokenName).value : (process.client && localStorage.getItem(tokenName)) || null
+    return conf?.tokenStorage === 'cookie'
+      ? callWithNuxt((nuxtApp as ReturnType<typeof useNuxtApp>), () => useCookie(tokenName).value)
+      : (process.client && localStorage.getItem(tokenName)) || null
   }
   type TAuthUpdate = {token?: string, client?: string, mode: 'login' | 'logout', skipResetStore?: boolean}
   const updateAuth = async ({ token, client, mode, skipResetStore }: TAuthUpdate) => {


### PR DESCRIPTION
Due to the asynchronous `nuxtApp.callHook` call in `getToken`, the Nuxt app context is no longer available when `useCookie` is called to retrieve the token cookie value. This causes the following error:

```
[nuxt] A composable that requires access to the Nuxt instance was called
outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function.
This is probably not a Nuxt bug.
Find out more at `https://nuxt.com/docs/guide/concepts/auto-imports#using-vue-and-nuxt-composables`.
```

With a stack trace (example):

```
at Module.useRequestEvent (./node_modules/nuxt/dist/app/composables/ssr.js:16:58)
at readRawCookies (./node_modules/nuxt/dist/app/composables/cookie.js:78:62)
at Module.useCookie (./node_modules/nuxt/dist/app/composables/cookie.js:23:19)
at getToken (./node_modules/@nuxtjs/apollo/dist/runtime/composables.mjs:47:68)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async ./src/middleware/customer-auth.ts:9:97
at async Object.callAsync (./node_modules/unctx/dist/index.mjs:72:16)
at async ./node_modules/nuxt/dist/pages/runtime/plugins/router.js:130:26
```

This can be circumvented by explicitly providing the previous Nuxt app context for the `useCookie` call using the internal `callWithNuxt` utility.