### PR TITLE
Unnecessary serialization on `cache.restore`

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -130,7 +130,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     })
 
     if (process.client && nuxtApp.payload.data[cacheKey]) {
-      cache.restore(destr(JSON.stringify(nuxtApp.payload.data[cacheKey])))
+      cache.restore(nuxtApp.payload.data[cacheKey])
     }
   }
 


### PR DESCRIPTION
The current implementation of `cache.restore` includes an unnecessary serialization step, which could potentially impact performance. To optimize the process and improve overall efficiency, this pull request removes the serialization step.

If there was a specific reason for the serialization that I might have overlooked, please let me know so that we can discuss it further and address any concerns accordingly.