### PR TITLE
fix: support function expressions in config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,6 +6,7 @@ import { useLogger, addPlugin, addImports, addTemplate, createResolver, defineNu
 import GraphQLPlugin from '@rollup/plugin-graphql'
 import { name, version } from '../package.json'
 import type { ClientConfig, NuxtApolloConfig, ErrorResponse } from './types'
+import { serializeConfig } from './serialize'
 
 export type { ClientConfig, ErrorResponse }
 
@@ -107,8 +108,8 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
         'export default {',
         ` proxyCookies: ${options.proxyCookies},`,
         ` clientAwareness: ${options.clientAwareness},`,
-        ` cookieAttributes: ${JSON.stringify(options.cookieAttributes)},`,
-        ` clients: ${JSON.stringify(clients)}`,
+        ` cookieAttributes: ${serializeConfig(options.cookieAttributes)},`,
+        ` clients: ${serializeConfig(clients)}`,
         '}'
       ].join('\n')
     }).dst

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,0 +1,22 @@
+/**
+ * Serialize config to be used in templates
+ * @param obj Config object
+ * @returns Stringified config with kept function expressions
+ */
+export const serializeConfig = (obj: any) => {
+  // Stringify function body
+  if (typeof obj === 'function') {
+    return obj.toString()
+  }
+
+  // Run recursively on objects and arrays
+  if (typeof obj === 'object') {
+    if (Array.isArray(obj)) {
+      return `[${obj.map(serializeConfig).join(', ')}]`
+    } else {
+      return `{${Object.entries(obj).map(([key, value]) => `${serializeConfig(key)}: ${serializeConfig(value)}`).join(', ')}}`
+    }
+  }
+
+  return JSON.stringify(obj)
+}


### PR DESCRIPTION
This PR adds support for use of function expressions inside Apollo config, e.g. to define custom type policies.
https://www.apollographql.com/docs/react/caching/cache-field-behavior

The current serializer, `JSON.stringify`, simply removes all function expressions as it cannot serialize them.
This is also mentioned in https://github.com/nuxt-modules/apollo/issues/443.

A common use case for this is offset-limit paginated queries where new entries may be merged with previously fetched results (instead of treating them as different queries).
https://www.apollographql.com/docs/react/pagination/offset-based#the-offsetlimitpagination-helper

