### PR TITLE
fix: async queries not reading "cache" option

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -48,7 +48,7 @@ const prep = (...args: any) => {
 
   const key = args?.[0]?.key || hash({ query: print(query), variables, clientId })
 
-  const fn = () => clients![clientId]?.query({ query, variables, fetchPolicy: 'no-cache' }).then(r => r.data)
+  const fn = () => clients![clientId]?.query({ query, variables, fetchPolicy: cache ? 'cache-first' : 'no-cache' }).then(r => r.data)
 
   return { key, query, clientId, variables, fn }
 }


### PR DESCRIPTION
I have to believe this was overlooked as there was a `cache` variable created and then just never used. 

If there was a specific reason to not allow async queries to use the cache, please let me know.

Otherwise this is quite a major bug that has been plaguing our site for a while in which we've had to implement workarounds that aren't very fun.