### PR TITLE
fix authType when setting in the specified client (#567)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -73,7 +73,7 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
           if (!configPaths[k]) { configPaths[k] = path }
         }
 
-        v.authType = v?.authType || (v?.authType === '' || v?.authType === null) ? null : options.authType
+        v.authType = (v?.authType === undefined ? options.authType : v?.authType) || null
         v.authHeader = v?.authHeader || options.authHeader
         v.tokenName = v?.tokenName || `apollo:${k}.token`
         v.tokenStorage = v?.tokenStorage || options.tokenStorage


### PR DESCRIPTION
It will take options autyType when client authType is undefined. And in the end, it will be changed to null if the final authType is falsy