### PR TITLE
fix: module types generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ohash": "^1.1.3"
   },
   "devDependencies": {
-    "@nuxt/module-builder": "^0.5.2",
+    "@nuxt/module-builder": "^0.5.4",
     "@nuxt/schema": "^3.8.0",
     "@nuxt/ui": "^0.4.1",
     "@nuxtjs/eslint-config-typescript": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@nuxt/module-builder':
-        specifier: ^0.5.2
-        version: 0.5.2(@nuxt/kit@3.8.0)(nuxi@3.9.1)(typescript@5.2.2)
+        specifier: ^0.5.4
+        version: 0.5.4(@nuxt/kit@3.8.0)(nuxi@3.9.1)(typescript@5.2.2)
       '@nuxt/schema':
         specifier: ^3.8.0
         version: 3.8.0(rollup@3.29.4)
@@ -1258,12 +1258,12 @@ packages:
       - rollup
       - supports-color
 
-  /@nuxt/module-builder@0.5.2(@nuxt/kit@3.8.0)(nuxi@3.9.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-MsnPTsa94VNrzV76RKCDS0C96uaKw9s3EbTtabI/BkAXOD4Ud1w6m0O20XUdI9tmRtE8Kbgyr4XUhD/YB3eeAw==}
+  /@nuxt/module-builder@0.5.4(@nuxt/kit@3.8.0)(nuxi@3.9.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-lCPh8s8LSfYqHgIMMsctDhz+AX1z6TnATkUes/GXc/No4kApC0zmJkQWrbtDRjmsWjElwl1kE7l7OzYdYc3d4w==}
     hasBin: true
     peerDependencies:
-      '@nuxt/kit': ^3.7.4
-      nuxi: ^3.9.0
+      '@nuxt/kit': ^3.8.1
+      nuxi: ^3.9.1
     dependencies:
       '@nuxt/kit': 3.8.0(rollup@3.29.4)
       citty: 0.1.4
@@ -1565,6 +1565,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: true
     bundledDependencies:
       - napi-wasm
@@ -5765,6 +5766,10 @@ packages:
     resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
     engines: {node: ^14 || ^16 || >=18}
     hasBin: true
+    dev: true
+
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
     dev: true
 
   /natural-compare@1.4.0:

--- a/src/module.ts
+++ b/src/module.ts
@@ -189,19 +189,26 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
 
 export const defineApolloClient = (config: ClientConfig) => config
 
+export interface RuntimeModuleHooks {
+  'apollo:auth': (params: { client: string, token: Ref<string | null> }) => void
+  'apollo:error': (error: ErrorResponse) => void
+}
+
+export interface ModuleRuntimeConfig {
+  apollo: NuxtApolloConfig<any>
+}
+
+export interface ModulePublicRuntimeConfig {
+  apollo: NuxtApolloConfig<any>
+}
+
 declare module '#app' {
-  interface RuntimeConfig {
-    // @ts-ignore
-    apollo: NuxtApolloConfig<any>
+  interface RuntimeNuxtHooks extends RuntimeModuleHooks {}
+}
 
-    // @ts-ignore
-    public:{
-      apollo: NuxtApolloConfig<any>
-    }
-  }
-
-  interface RuntimeNuxtHooks {
-    'apollo:auth': (params: { client: string, token: Ref<string | null> }) => void
-    'apollo:error': (error: ErrorResponse) => void
-  }
+declare module '@nuxt/schema' {
+  interface NuxtConfig { ['apollo']?: Partial<ModuleOptions> }
+  interface NuxtOptions { ['apollo']?: ModuleOptions }
+  interface RuntimeConfig extends ModuleRuntimeConfig {}
+  interface PublicRuntimeConfig extends ModulePublicRuntimeConfig {}
 }


### PR DESCRIPTION
* Resolves #558 

This should fix the module types generated on build by `@nuxt/module-builder` in `dist/types.d.ts`, these are [missing runtime hooks](https://www.npmjs.com/package/@nuxtjs/apollo/v/5.0.0-alpha.8?activeTab=code) right now.

