### PR TITLE
fix: passing headers in websocket connectionParams

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -74,7 +74,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
           if (!auth) { return }
 
-          return { [clientConfig.authHeader!]: auth }
+          return { headers: { [clientConfig.authHeader!]: auth } }
         }
       })
 


### PR DESCRIPTION
see #555 for details. Alternative solutions welcome, however this solution allows Nuxt Apollo to authenticate with Hasura.