### PR TITLE
Allow for a more granular auto-import config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -28,7 +28,10 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
     }
   },
   defaults: {
-    autoImports: true,
+    autoImports: {
+      gql: true,
+      'vue-apollo': true
+    },
     authType: 'Bearer',
     authHeader: 'Authorization',
     tokenStorage: 'cookie',
@@ -122,31 +125,37 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
     // TODO: Integrate @vue/apollo-components?
 
     addImports([
-      { name: 'gql', from: 'graphql-tag' },
-      ...[
-        'useApollo',
-        'useAsyncQuery',
-        'useLazyAsyncQuery'
-      ].map(n => ({ name: n, from: resolve('runtime/composables') })),
-      ...(!options?.autoImports
-        ? []
-        : [
-            'useQuery',
-            'useLazyQuery',
-            'useMutation',
-            'useSubscription',
+      'useApollo',
+      'useAsyncQuery',
+      'useLazyAsyncQuery'
+    ].map(n => ({ name: n, from: resolve('runtime/composables') })))
 
-            'useApolloClient',
+    // Resolve individual autoImport config
+    const shouldAutoImportGqlTag = typeof options.autoImports === 'boolean' ? options.autoImports : options.autoImports?.gql
+    const shouldAutoImportVueApolloComposables = typeof options.autoImports === 'boolean' ? options.autoImports : options.autoImports?.['vue-apollo']
 
-            'useQueryLoading',
-            'useMutationLoading',
-            'useSubscriptionLoading',
-
-            'useGlobalQueryLoading',
-            'useGlobalMutationLoading',
-            'useGlobalSubscriptionLoading'
-          ].map(n => ({ name: n, from: '@vue/apollo-composable' })))
-    ])
+    if (shouldAutoImportGqlTag) {
+      addImports({ name: 'gql', from: 'graphql-tag' })
+    }
+    if (shouldAutoImportVueApolloComposables) {
+      addImports([
+        ...(!options?.autoImports
+          ? []
+          : [
+              'useQuery',
+              'useLazyQuery',
+              'useMutation',
+              'useSubscription',
+              'useApolloClient',
+              'useQueryLoading',
+              'useMutationLoading',
+              'useSubscriptionLoading',
+              'useGlobalQueryLoading',
+              'useGlobalMutationLoading',
+              'useGlobalSubscriptionLoading'
+            ].map(n => ({ name: n, from: '@vue/apollo-composable' })))
+      ])
+    }
 
     nuxt.hook('vite:extendConfig', (config) => {
       config.optimizeDeps = config.optimizeDeps || {}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,6 +11,18 @@ export type NuxtAppApollo = Partial<{
   _apolloWsClients?: Record<string, RestartableClient>;
 }>;
 
+export type AutoImportConfig = {
+  /** 
+   * Specify if the `gql` tag function should be auto-imported
+   * @default true
+   */
+  gql: boolean,
+  /**
+   * Specify if vue-apollo composables should be auto-imported
+   */
+  'vue-apollo': boolean
+}
+
 export type ClientConfig = {
   /**
    * The GraphQL endpoint.
@@ -110,11 +122,11 @@ export type ClientConfig = {
 
 export interface NuxtApolloConfig<T = ClientConfig> {
   /**
-   * Determine if vue-apollo composables should be automatically imported.
-   * @type {boolean}
+   * Determine if vue-apollo composables and `gql` function should be automatically imported.
+   * @type {boolean | AutoImportConfig}
    * @default true
    **/
-  autoImports?: boolean;
+  autoImports?: boolean | AutoImportConfig;
 
   /**
    * Configuration of the Apollo clients.


### PR DESCRIPTION
This PR adds the ability to selectively disable auto-imports for the `gql` function or vue-apollo composables. 

```
export default defineNuxtConfig({
// ...
  apollo: {
    autoImports: {
      gql: false,
      'vue-apollo': true
    },
})
```

The motivation is to allow for custom autoimports for the `gql` function from other sources. One particular use case is when looking to add an autoimport from the autogenerated tag function provided by graphql-codegen that is typesafe