### PR TITLE
Updated spacex public graphql endpoint url

### DIFF
--- a/docs/content/1.getting-started/1.quick-start.md
+++ b/docs/content/1.getting-started/1.quick-start.md
@@ -41,7 +41,7 @@ Integrate Nuxt Apollo into your project.
       apollo: {
         clients: {
           default: {
-            httpEndpoint: 'https://api.spacex.land/graphql'
+            httpEndpoint: 'https://spacex-production.up.railway.app'
           }
         },
       },


### PR DESCRIPTION
The URL 'https://api.spacex.land/graphql' is no longer valid and therefore the example not practical. The endpoint URL was updated as per "SpaceX-pxxbxen@current".