### PR TITLE
fix: fix invalid url

### DIFF
--- a/docs/content/1.getting-started/1.quick-start.md
+++ b/docs/content/1.getting-started/1.quick-start.md
@@ -41,7 +41,7 @@ Integrate Nuxt Apollo into your project.
       apollo: {
         clients: {
           default: {
-            httpEndpoint: 'https://api.spacex.land/graphql'
+            httpEndpoint: 'https://studio.apollographql.com/public/SpaceX-pxxbxen/variant/current/explorer'
           }
         },
       },


### PR DESCRIPTION
The Space Land API is deprecated now for both REST API and GraphQL API. (https://github.com/SpaceXLand/api/issues/241#issuecomment-1397096235)

This is the replacement of the GraphQL server of Space Land. (https://github.com/dremendes/spacex-launches/pull/4)
