### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/playground/components/GithubDemo.vue
+++ b/playground/components/GithubDemo.vue
@@ -53,7 +53,7 @@ const { getToken, onLogin, onLogout } = useApollo()
 const githubToken = ref<string | null>(null)
 
 // for testing with cookie `tokenStorage`
-if (process.server) { githubToken.value = await getToken('github') }
+if (import.meta.server) { githubToken.value = await getToken('github') }
 
 onMounted(async () => {
   githubToken.value = await getToken('github')

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -70,7 +70,7 @@ export const useApollo = () => {
 
     const tokenName = conf.tokenName!
 
-    return conf?.tokenStorage === 'cookie' ? useCookie(tokenName).value : (process.client && localStorage.getItem(tokenName)) || null
+    return conf?.tokenStorage === 'cookie' ? useCookie(tokenName).value : (import.meta.client && localStorage.getItem(tokenName)) || null
   }
   type TAuthUpdate = {token?: string, client?: string, mode: 'login' | 'logout', skipResetStore?: boolean}
   const updateAuth = async ({ token, client, mode, skipResetStore }: TAuthUpdate) => {
@@ -88,7 +88,7 @@ export const useApollo = () => {
       if (!cookie.value && mode === 'logout') { return }
 
       cookie.value = (mode === 'login' && token) || null
-    } else if (process.client && conf?.tokenStorage === 'localStorage') {
+    } else if (import.meta.client && conf?.tokenStorage === 'localStorage') {
       if (mode === 'login' && token) {
         localStorage.setItem(tokenName, token)
       } else if (mode === 'logout') {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -13,7 +13,7 @@ import { ref, useCookie, defineNuxtPlugin, useRequestHeaders } from '#imports'
 import NuxtApollo from '#apollo'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  const requestCookies = (process.server && NuxtApollo.proxyCookies && useRequestHeaders(['cookie'])) || undefined
+  const requestCookies = (import.meta.server && NuxtApollo.proxyCookies && useRequestHeaders(['cookie'])) || undefined
 
   const clients: { [key: string]: ApolloClient<any> } = {}
 
@@ -25,12 +25,12 @@ export default defineNuxtPlugin((nuxtApp) => {
 
       if (!token.value) {
         if (clientConfig.tokenStorage === 'cookie') {
-          if (process.client) {
+          if (import.meta.client) {
             token.value = useCookie(clientConfig.tokenName!).value
           } else if (requestCookies?.cookie) {
             token.value = requestCookies.cookie.split(';').find(c => c.trim().startsWith(`${clientConfig.tokenName}=`))?.split('=')?.[1]
           }
-        } else if (process.client && clientConfig.tokenStorage === 'localStorage') {
+        } else if (import.meta.client && clientConfig.tokenStorage === 'localStorage') {
           token.value = localStorage.getItem(clientConfig.tokenName!)
         }
 
@@ -60,13 +60,13 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     const httpLink = authLink.concat(createHttpLink({
       ...(clientConfig?.httpLinkOptions && clientConfig.httpLinkOptions),
-      uri: (process.client && clientConfig.browserHttpEndpoint) || clientConfig.httpEndpoint,
+      uri: (import.meta.client && clientConfig.browserHttpEndpoint) || clientConfig.httpEndpoint,
       headers: { ...(clientConfig?.httpLinkOptions?.headers || {}) }
     }))
 
     let wsLink: GraphQLWsLink | null = null
 
-    if (process.client && clientConfig.wsEndpoint) {
+    if (import.meta.client && clientConfig.wsEndpoint) {
       const wsClient = createRestartableClient({
         ...clientConfig.wsLinkOptions,
         url: clientConfig.wsEndpoint,
@@ -113,7 +113,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       link,
       cache,
       ...(NuxtApollo.clientAwareness && { name: key }),
-      ...(process.server
+      ...(import.meta.server
         ? { ssrMode: true }
         : { ssrForceFetchDelay: 100 }),
       connectToDevTools: clientConfig.connectToDevTools || false,
@@ -130,7 +130,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       nuxtApp.payload.data[cacheKey] = cache.extract()
     })
 
-    if (process.client && nuxtApp.payload.data[cacheKey]) {
+    if (import.meta.client && nuxtApp.payload.data[cacheKey]) {
       cache.restore(destr(JSON.stringify(nuxtApp.payload.data[cacheKey])))
     }
   }


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)