### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.getting-started/1.quick-start.md
+++ b/docs/content/1.getting-started/1.quick-start.md
@@ -7,18 +7,9 @@ Integrate Nuxt Apollo into your project.
 ## Installation
 
 1. Add the `@nuxtjs/apollo` development dependency.
-
-    ::code-group
-    ```bash [Yarn]
-    yarn add -D @nuxtjs/apollo@next
+    ```bash
+    npx nuxi@latest module add apollo
     ```
-    ```bash [NPM]
-    npm i -D @nuxtjs/apollo@next
-    ```
-    ```bash [pnpm]
-    pnpm add @nuxtjs/apollo@next --save-dev
-    ```
-    ::
 
 2. Enable the module.
 

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -12,7 +12,7 @@ cta:
 secondary:
   - Star on GitHub →
   - https://github.com/nuxt-modules/apollo-module
-snippet: yarn add -D @nuxtjs/apollo@next
+snippet: npx nuxi@latest module add apollo
 ---
 
 #title


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
