### PR TITLE
chore: indicate compatibility with new v4 major`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ export default defineNuxtModule<NuxtApolloConfig<any>>({
     version,
     configKey: 'apollo',
     compatibility: {
-      nuxt: '^3.0.0-rc.9'
+      nuxt: '>=3.0.0-rc.9'
     }
   },
   defaults: {


### PR DESCRIPTION

With Nuxt 4 on the horizon, this updates the module compatibility definition to allow it to be installed on Nuxt v4. (Otherwise Nuxt will indicate the module might not be compatible.)

You can follow this and other changes in https://github.com/nuxt/nuxt/issues/27613 - please feel free to provide feedback as well!