### PR TITLE
fix: composable loosing contexts during tests

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -55,7 +55,6 @@ export default defineNuxtModule<ModuleOptions>({
       'tslib',
       '@wry/context',
       '@apollo/client',
-      '@vue/apollo-composable',
       'ts-invariant/process')
 
     const clients: Record<string, ClientConfig> = {}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

- https://github.com/nuxt-modules/apollo/issues/638

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes `@vue/apollo-composable` from `nuxt.options.build.transpile`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Adding `@vue/apollo-composable` to `nuxt.options.build.transpile` causes all kinds of bugs since the module might be imported & executed twice. 

1. Via `nuxt.options.build.transpile` ([here](https://github.com/nuxt-modules/apollo/blob/64e35de7bcfc5f45cd6571841593610646868e7f/src/module.ts#L58))
2. Via plugin import ([here](https://github.com/nuxt-modules/apollo/blob/64e35de7bcfc5f45cd6571841593610646868e7f/src/runtime/plugin.ts#L5))

This causes some composables (e.g. `useQuery` or `useMutation`) to loose context (`currentApolloClients`) in specific scenarios.

One such scenario is running vitest & @nuxt/test-utils test with `useQuery` or `useMutation`:

```log
Apollo client with id default not found. Use an app.runWithContext() or provideApolloClient() if you are outside of a component setup.
```
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
