### PR TITLE
fix: handle null serialization

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -10,7 +10,7 @@ export const serializeConfig = (obj: any): string => {
   }
 
   // Run recursively on objects and arrays
-  if (typeof obj === 'object') {
+  if (typeof obj === 'object' && obj !== null) {
     if (Array.isArray(obj)) {
       return `[${obj.map(serializeConfig).join(', ')}]`
     } else {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #636

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds condition check during serialization, to avoid serialize `null` value as object, as `typeof null === 'object'`.
It fix serialization issue for `@nuxtjs/apollo` config provided in `nuxt.config.ts`, where it cannot handle serialization for `null` value, which is accepted value for `client.authType`.
