### PR TITLE
enhancement: Add support for custom connectionParams in websocket initializer

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -87,13 +87,14 @@ export default defineNuxtPlugin((nuxtApp) => {
           const auth = await getAuth()
           if (!auth) { return connectionParams }
 
-          const headers = connectionParams?.headers || {}
-
-          // merge any existing connection params with the auth header
-          return {
-            headers: { [clientConfig.authHeader!]: auth, ...headers },
-            ...connectionParams
+          // merge connection headers with the auth header
+          const headers = {
+            [clientConfig.authHeader!]: auth,
+            ...(connectionParams?.headers || {})
           }
+
+          // merge existing connection params with headers
+          return { ...connectionParams, headers }
         }
       })
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -29,7 +29,7 @@ export type ClientConfig = {
    * Provide additional configuration for the `GraphQLWsLink`.
    * See https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/client.ClientOptions.md
    **/
-  wsLinkOptions?: Omit<ClientOptions, 'url' | 'connectionParams'>;
+  wsLinkOptions?: Omit<ClientOptions, 'url'>;
 
   /**
    * Specify a websocket endpoint to be used for subscriptions.


### PR DESCRIPTION
### 🔗 Linked issue

Related #555 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Adds support for configuring any number of options in `connectionParams` within the `graphql-ws` client. Previously, `connectionParams` was a disabled option that was ignored when supplied.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
