### PR TITLE
fix for connectToDevTools

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -135,7 +135,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       ...(import.meta.server
         ? { ssrMode: true }
         : { ssrForceFetchDelay: 100 }),
-      connectToDevTools: clientConfig.connectToDevTools || false,
+      devtools: { enabled: clientConfig.connectToDevTools || false },
       defaultOptions: clientConfig?.defaultOptions
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix for a Nuxt Warning | connectToDevTools should be replaced with devtools.enabled in Apollo Client v3.14+

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
