### PR TITLE
fix: useAsyncQuery options

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -139,7 +139,7 @@ const prep = <T> (...args: any[]) => {
     context = firstArg.context!
     clientId = firstArg.clientId
 
-    if (typeof args?.[1] === 'object' && args?.[1] !== null && 'watch' in args[1]) {
+    if (typeof args?.[1] === 'object' && args?.[1] !== null) {
       options = args?.[1]
     }
   } else {


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt-modules/apollo/issues/667

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Options in useAsyncData don't work, if 'watch' isn't passed in. Need remove checking: && 'watch' in args[1]
